### PR TITLE
Fix coding norms.

### DIFF
--- a/test/monio/MonioReadWrite.h
+++ b/test/monio/MonioReadWrite.h
@@ -60,6 +60,7 @@ class MonioReadWrite : public oops::Test{
  public:
   MonioReadWrite() {}
   virtual ~MonioReadWrite() {}
+
  private:
   std::string testid() const override {
     return "monio::test::MonioReadWrite";


### PR DESCRIPTION
This fixes a coding error:

/home/h01/frwd/cylc-run/MonioCodingNorms/share/mo-bundle/monio/test/monio/MonioReadWrite.h:63:  "private:" should be preceded by a blank line  [whitespace/blank_line] [3]

Test output is here: http://fcm1/cylc-review/taskjobs/frwd?&suite=MonioCodingNorms