### PR TITLE
Introduction of AttributeDouble from LFRic-Lite

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,6 +19,8 @@ monio/AtlasWriter.cc
 monio/AtlasWriter.h
 monio/AttributeBase.cc
 monio/AttributeBase.h
+monio/AttributeDouble.cc
+monio/AttributeDouble.h
 monio/AttributeInt.cc
 monio/AttributeInt.h
 monio/AttributeString.cc

--- a/src/monio/AtlasWriter.cc
+++ b/src/monio/AtlasWriter.cc
@@ -38,16 +38,16 @@ monio::AtlasWriter::AtlasWriter(const eckit::mpi::Comm& mpiCommunicator,
 void monio::AtlasWriter::writeFieldSetToFile(const atlas::FieldSet& fieldSet,
                                              const std::string outputFilePath) {
   oops::Log::debug() << "AtlasWriter::writeFieldSetToFile()" << std::endl;
-  if (atlas::mpi::rank() == monio::consts::kMPIRankOwner) {
+  if (atlas::mpi::rank() == consts::kMPIRankOwner) {
     if (outputFilePath.length() != 0) {
       monio::Metadata metadata;
       monio::Data data;
       monio::AtlasWriter atlasWriter(atlas::mpi::comm(),
-                                         monio::consts::kMPIRankOwner);
+                                         consts::kMPIRankOwner);
       atlasWriter.populateMetadataAndDataWithFieldSet(metadata, data, fieldSet);
 
       monio::Writer writer(atlas::mpi::comm(),
-                               monio::consts::kMPIRankOwner,
+                               consts::kMPIRankOwner,
                                outputFilePath);
       writer.writeMetadata(metadata);
       writer.writeVariablesData(metadata, data);
@@ -72,11 +72,11 @@ void monio::AtlasWriter::writeIncrementsToFile(atlas::FieldSet& fieldSet,
 
         readMetadata.clearGlobalAttributes();
 
-        readMetadata.deleteDimension(std::string(monio::consts::kTimeDimName));
-        readMetadata.deleteDimension(std::string(monio::consts::kTileDimName));
+        readMetadata.deleteDimension(std::string(consts::kTimeDimName));
+        readMetadata.deleteDimension(std::string(consts::kTileDimName));
 
-        readData.deleteContainer(std::string(monio::consts::kTimeVarName));
-        readData.deleteContainer(std::string(monio::consts::kTileVarName));
+        readData.deleteContainer(std::string(consts::kTimeVarName));
+        readData.deleteContainer(std::string(consts::kTileVarName));
 
         reconcileMetadataWithData(readMetadata, readData);
 
@@ -85,7 +85,7 @@ void monio::AtlasWriter::writeIncrementsToFile(atlas::FieldSet& fieldSet,
                                                  fieldMetadataVec, fieldSet, lfricAtlasMap);
 
         monio::Writer writer(atlas::mpi::comm(),
-                             monio::consts::kMPIRankOwner,
+                             consts::kMPIRankOwner,
                              outputFilePath);
         writer.writeMetadata(readMetadata);
         writer.writeVariablesData(readMetadata, readData);
@@ -314,7 +314,7 @@ void monio::AtlasWriter::populateMetadataAndDataWithFieldSet(Metadata& metadata,
       }
       for (auto& dimSize : dimVec) {
         std::string dimName = metadata.getDimensionName(dimSize);
-        if (dimName == monio::consts::kNotFoundError) {
+        if (dimName == consts::kNotFoundError) {
           dimName = "dim" + std::to_string(dimCount);
           metadata.addDimension(dimName, dimSize);
           dimCount++;

--- a/src/monio/AttributeDouble.cc
+++ b/src/monio/AttributeDouble.cc
@@ -1,0 +1,20 @@
+/*
+ * (C) Crown Copyright 2023 Met Office
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+#include "AttributeDouble.h"
+
+#include "Constants.h"
+
+monio::AttributeDouble::AttributeDouble(const std::string& name, const double value) :
+  AttributeBase(name, monio::consts::eDouble), value_(value) {}
+
+const std::string& monio::AttributeDouble::getName() const {
+  return name_;
+}
+
+const double monio::AttributeDouble::getValue() const {
+  return value_;
+}

--- a/src/monio/AttributeDouble.cc
+++ b/src/monio/AttributeDouble.cc
@@ -9,7 +9,7 @@
 #include "Constants.h"
 
 monio::AttributeDouble::AttributeDouble(const std::string& name, const double value) :
-  AttributeBase(name, monio::consts::eDouble), value_(value) {}
+  AttributeBase(name, consts::eDouble), value_(value) {}
 
 const std::string& monio::AttributeDouble::getName() const {
   return name_;

--- a/src/monio/AttributeDouble.h
+++ b/src/monio/AttributeDouble.h
@@ -1,0 +1,31 @@
+/*
+ * (C) Crown Copyright 2023 Met Office
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+#pragma once
+
+#include <string>
+
+#include "AttributeBase.h"
+
+namespace monio {
+/// \brief Concrete class for integer attributes of a NetCDF file
+class AttributeDouble : public AttributeBase {
+ public:
+  AttributeDouble(const std::string& name, const double value);
+
+  AttributeDouble()                                  = delete;  //!< Deleted default constructor
+  AttributeDouble(AttributeDouble&&)                 = delete;  //!< Deleted move constructor
+  AttributeDouble(const AttributeDouble&)            = delete;  //!< Deleted copy constructor
+  AttributeDouble& operator=(AttributeDouble&&)      = delete;  //!< Deleted move assignment
+  AttributeDouble& operator=(const AttributeDouble&) = delete;  //!< Deleted copy assignment
+
+  const std::string& getName() const;
+  const double getValue() const;
+
+ private:
+  double value_;
+};
+}  // namespace monio

--- a/src/monio/AttributeInt.cc
+++ b/src/monio/AttributeInt.cc
@@ -11,7 +11,7 @@
 #include "Constants.h"
 
 monio::AttributeInt::AttributeInt(const std::string& name, const int value) :
-  AttributeBase(name, monio::consts::eInt), value_(value) {}
+  AttributeBase(name, consts::eInt), value_(value) {}
 
 const std::string& monio::AttributeInt::getName() const {
   return name_;

--- a/src/monio/AttributeString.cc
+++ b/src/monio/AttributeString.cc
@@ -12,7 +12,7 @@
 
 monio::AttributeString::AttributeString(const std::string& name,
                                                         const std::string& value) :
-    AttributeBase(name, monio::consts::eString), value_(value) {}
+    AttributeBase(name, consts::eString), value_(value) {}
 
 const std::string& monio::AttributeString::getName() const {
   return name_;

--- a/src/monio/Data.cc
+++ b/src/monio/Data.cc
@@ -52,7 +52,7 @@ bool monio::operator==(const monio::Data& lhs, const monio::Data& rhs) {
 
       if (lhsDataType == rhsDataType && lhsName == rhsName) {
         switch (lhsDataType) {
-          case monio::consts::eDataTypes::eDouble: {
+          case consts::eDataTypes::eDouble: {
             std::shared_ptr<DataContainerDouble> lhsDataContainerDouble =
               std::static_pointer_cast<DataContainerDouble>(lhsDataContainer);
             std::shared_ptr<DataContainerDouble> rhsDataContainerDouble =
@@ -63,7 +63,7 @@ bool monio::operator==(const monio::Data& lhs, const monio::Data& rhs) {
               return false;
             break;
           }
-          case monio::consts::eDataTypes::eFloat: {
+          case consts::eDataTypes::eFloat: {
             std::shared_ptr<DataContainerFloat> lhsDataContainerFloat =
               std::static_pointer_cast<DataContainerFloat>(lhsDataContainer);
             std::shared_ptr<DataContainerFloat> rhsDataContainerFloat =
@@ -74,7 +74,7 @@ bool monio::operator==(const monio::Data& lhs, const monio::Data& rhs) {
               return false;
             break;
           }
-          case monio::consts::eDataTypes::eInt: {
+          case consts::eDataTypes::eInt: {
             std::shared_ptr<DataContainerInt> lhsDataContainerInt =
               std::static_pointer_cast<DataContainerInt>(lhsDataContainer);
             std::shared_ptr<DataContainerInt> rhsDataContainerInt =

--- a/src/monio/DataContainerFloat.cc
+++ b/src/monio/DataContainerFloat.cc
@@ -13,7 +13,7 @@
 #include "Constants.h"
 
 monio::DataContainerFloat::DataContainerFloat(const std::string& name) :
-  DataContainerBase(name, monio::consts::eFloat) {}
+  DataContainerBase(name, consts::eFloat) {}
 
 const std::string& monio::DataContainerFloat::getName() const {
   return name_;

--- a/src/monio/DataContainerInt.cc
+++ b/src/monio/DataContainerInt.cc
@@ -13,7 +13,7 @@
 #include "Constants.h"
 
 monio::DataContainerInt::DataContainerInt(const std::string& name) :
-  DataContainerBase(name, monio::consts::eInt) {}
+  DataContainerBase(name, consts::eInt) {}
 
 const std::string& monio::DataContainerInt::getName() const {
   return name_;

--- a/src/monio/Metadata.cc
+++ b/src/monio/Metadata.cc
@@ -17,6 +17,7 @@
 
 #include "oops/util/Logger.h"
 
+#include "AttributeDouble.h"
 #include "AttributeInt.h"
 #include "AttributeString.h"
 #include "Utils.h"
@@ -77,6 +78,15 @@ bool monio::operator==(const monio::Metadata& lhs,
 
             if (lhsVarAttrType == rhsVarAttrType && lhsVarAttrName == rhsVarAttrName) {
               switch (lhsVarAttrType) {
+                case monio::consts::eDataTypes::eDouble: {
+                 std::shared_ptr<monio::AttributeDouble> lhsVarAttrDbl =
+                        std::dynamic_pointer_cast<monio::AttributeDouble>(lhsVarAttr);
+                  std::shared_ptr<monio::AttributeDouble> rhsVarAttrDbl =
+                        std::dynamic_pointer_cast<monio::AttributeDouble>(rhsVarAttr);
+                  if (lhsVarAttrDbl->getValue() != rhsVarAttrDbl->getValue())
+                    return false;
+                  break;
+                }
                 case monio::consts::eDataTypes::eInt: {
                  std::shared_ptr<monio::AttributeInt> lhsVarAttrInt =
                         std::dynamic_pointer_cast<monio::AttributeInt>(lhsVarAttr);
@@ -389,6 +399,12 @@ void monio::Metadata::printVariables() {
       int dataType = netCDFAttr->getType();
 
       switch (dataType) {
+        case monio::consts::eDataTypes::eDouble: {
+            std::shared_ptr<monio::AttributeDouble> netCDFAttrDbl =
+                        std::dynamic_pointer_cast<monio::AttributeDouble>(netCDFAttr);
+          oops::Log::debug() << netCDFAttrDbl->getValue() << std::endl;
+          break;
+        }
         case monio::consts::eDataTypes::eInt: {
           std::shared_ptr<monio::AttributeInt> netCDFAttrInt =
                         std::dynamic_pointer_cast<monio::AttributeInt>(netCDFAttr);
@@ -415,6 +431,12 @@ void monio::Metadata::printGlobalAttrs() {
     std::shared_ptr<AttributeBase> globalAttr = globAttrPair.second;
     int type = globalAttr->getType();
     switch (type) {
+      case monio::consts::eDataTypes::eDouble: {
+        std::shared_ptr<monio::AttributeDouble> globAttrDbl =
+                        std::dynamic_pointer_cast<monio::AttributeDouble>(globalAttr);
+        oops::Log::debug() << " = " << globAttrDbl->getValue() << " ;"  << std::endl;
+        break;
+      }
       case monio::consts::eDataTypes::eInt: {
         std::shared_ptr<monio::AttributeInt> globalAttrInt =
                         std::dynamic_pointer_cast<monio::AttributeInt>(globalAttr);

--- a/src/monio/Metadata.cc
+++ b/src/monio/Metadata.cc
@@ -78,7 +78,7 @@ bool monio::operator==(const monio::Metadata& lhs,
 
             if (lhsVarAttrType == rhsVarAttrType && lhsVarAttrName == rhsVarAttrName) {
               switch (lhsVarAttrType) {
-                case monio::consts::eDataTypes::eDouble: {
+                case consts::eDataTypes::eDouble: {
                  std::shared_ptr<monio::AttributeDouble> lhsVarAttrDbl =
                         std::dynamic_pointer_cast<monio::AttributeDouble>(lhsVarAttr);
                   std::shared_ptr<monio::AttributeDouble> rhsVarAttrDbl =
@@ -87,7 +87,7 @@ bool monio::operator==(const monio::Metadata& lhs,
                     return false;
                   break;
                 }
-                case monio::consts::eDataTypes::eInt: {
+                case consts::eDataTypes::eInt: {
                  std::shared_ptr<monio::AttributeInt> lhsVarAttrInt =
                         std::dynamic_pointer_cast<monio::AttributeInt>(lhsVarAttr);
                   std::shared_ptr<monio::AttributeInt> rhsVarAttrInt =
@@ -96,7 +96,7 @@ bool monio::operator==(const monio::Metadata& lhs,
                     return false;
                   break;
                 }
-                case monio::consts::eDataTypes::eString: {
+                case consts::eDataTypes::eString: {
                   std::shared_ptr<monio::AttributeString> lhsVarAttrStr =
                         std::dynamic_pointer_cast<monio::AttributeString>(lhsVarAttr);
                   std::shared_ptr<monio::AttributeString> rhsVarAttrStr =
@@ -151,7 +151,7 @@ std::string monio::Metadata::getDimensionName(const int dimValue) {
       return it->first;
     }
   }
-  return std::string(monio::consts::kNotFoundError);
+  return std::string(consts::kNotFoundError);
 }
 
 std::shared_ptr<monio::Variable> monio::Metadata::getVariable(const std::string& varName) {
@@ -314,7 +314,7 @@ int monio::Metadata::getDataFormat() {
       std::shared_ptr<monio::AttributeString> dataFormatAttr =
             std::dynamic_pointer_cast<monio::AttributeString>(globalAttr.second);
       std::string dataFormatValue = dataFormatAttr->getValue();
-      if (dataFormatValue == monio::consts::kNamingJediName) {
+      if (dataFormatValue == consts::kNamingJediName) {
         dataFormatRet = consts::eJediNaming;
       }
     }
@@ -371,8 +371,8 @@ void monio::Metadata::print() {
 void monio::Metadata::printVariables() {
   for (auto const& var : variables_) {
     std::shared_ptr<Variable> netCDFVar = var.second;
-    oops::Log::debug() << monio::consts::kTabSpace <<
-                          monio::consts::kDataTypeNames[netCDFVar->getType()] <<
+    oops::Log::debug() << consts::kTabSpace <<
+                          consts::kDataTypeNames[netCDFVar->getType()] <<
                            " " << netCDFVar->getName();
 
     std::vector<std::string> varDims = netCDFVar->getDimensionNames();
@@ -392,26 +392,26 @@ void monio::Metadata::printVariables() {
     for (auto const& varAttrPair : varAttrsMap) {
       std::shared_ptr<AttributeBase> netCDFAttr = varAttrPair.second;
 
-      oops::Log::debug() << monio::consts::kTabSpace <<
-                            monio::consts::kTabSpace <<
+      oops::Log::debug() << consts::kTabSpace <<
+                            consts::kTabSpace <<
                             netCDFVar->getName() << ":" <<
                             netCDFAttr->getName() << " = ";
       int dataType = netCDFAttr->getType();
 
       switch (dataType) {
-        case monio::consts::eDataTypes::eDouble: {
+        case consts::eDataTypes::eDouble: {
             std::shared_ptr<monio::AttributeDouble> netCDFAttrDbl =
                         std::dynamic_pointer_cast<monio::AttributeDouble>(netCDFAttr);
           oops::Log::debug() << netCDFAttrDbl->getValue() << std::endl;
           break;
         }
-        case monio::consts::eDataTypes::eInt: {
+        case consts::eDataTypes::eInt: {
           std::shared_ptr<monio::AttributeInt> netCDFAttrInt =
                         std::dynamic_pointer_cast<monio::AttributeInt>(netCDFAttr);
           oops::Log::debug() << netCDFAttrInt->getValue() << " ;" << std::endl;
           break;
         }
-        case monio::consts::eDataTypes::eString: {
+        case consts::eDataTypes::eString: {
             std::shared_ptr<monio::AttributeString> netCDFAttrStr =
                         std::dynamic_pointer_cast<monio::AttributeString>(netCDFAttr);
           oops::Log::debug() << std::quoted(netCDFAttrStr->getValue()) << std::endl;
@@ -427,23 +427,23 @@ void monio::Metadata::printVariables() {
 
 void monio::Metadata::printGlobalAttrs() {
   for (const auto& globAttrPair : globalAttrs_) {
-    oops::Log::debug() << monio::consts::kTabSpace << globAttrPair.first;
+    oops::Log::debug() << consts::kTabSpace << globAttrPair.first;
     std::shared_ptr<AttributeBase> globalAttr = globAttrPair.second;
     int type = globalAttr->getType();
     switch (type) {
-      case monio::consts::eDataTypes::eDouble: {
+      case consts::eDataTypes::eDouble: {
         std::shared_ptr<monio::AttributeDouble> globAttrDbl =
                         std::dynamic_pointer_cast<monio::AttributeDouble>(globalAttr);
         oops::Log::debug() << " = " << globAttrDbl->getValue() << " ;"  << std::endl;
         break;
       }
-      case monio::consts::eDataTypes::eInt: {
+      case consts::eDataTypes::eInt: {
         std::shared_ptr<monio::AttributeInt> globalAttrInt =
                         std::dynamic_pointer_cast<monio::AttributeInt>(globalAttr);
         oops::Log::debug() << globalAttrInt->getValue() << " ;" << std::endl;
         break;
       }
-      case monio::consts::eDataTypes::eString: {
+      case consts::eDataTypes::eString: {
         std::shared_ptr<monio::AttributeString> globAttrStr =
                         std::dynamic_pointer_cast<monio::AttributeString>(globalAttr);
         oops::Log::debug() << " = " << std::quoted(globAttrStr->getValue()) << " ;"  << std::endl;
@@ -458,7 +458,7 @@ void monio::Metadata::printGlobalAttrs() {
 template<typename T>
 void monio::Metadata::printMap(const std::map<std::string, T>& map) {
   for (const auto& entry : map) {
-    oops::Log::debug() << monio::consts::kTabSpace << entry.first <<
+    oops::Log::debug() << consts::kTabSpace << entry.first <<
                            " = " << entry.second << " ;" << std::endl;
   }
 }

--- a/src/monio/Monio.cc
+++ b/src/monio/Monio.cc
@@ -55,21 +55,21 @@ void monio::Monio::readBackground(atlas::FieldSet& localFieldSet,
         reader_.openFile(fileData);
         reader_.readMetadata(fileData);
         std::vector<std::string> meshVars =
-            fileData.getMetadata().findVariableNames(std::string(monio::consts::kLfricMeshTerm));
+            fileData.getMetadata().findVariableNames(std::string(consts::kLfricMeshTerm));
         reader_.readFullData(fileData, meshVars);
         createLfricAtlasMap(fileData, grid);
 
-        reader_.readFullDatum(fileData, std::string(monio::consts::kTimeVarName));
+        reader_.readFullDatum(fileData, std::string(consts::kTimeVarName));
         createDateTimes(fileData,
-                        std::string(monio::consts::kTimeVarName),
-                        std::string(monio::consts::kTimeOriginName));
+                        std::string(consts::kTimeVarName),
+                        std::string(consts::kTimeOriginName));
       }
       FileData fileData = getFileData(grid.name());
       // Read fields into memory
       reader_.readDatumAtTime(fileData,
                               fieldMetadata.lfricReadName,
                               dateTime,
-                              std::string(monio::consts::kTimeDimName));
+                              std::string(consts::kTimeDimName));
       atlasReader_.populateFieldWithDataContainer(
                                        globalField,
                                        fileData.getData().getContainer(fieldMetadata.lfricReadName),
@@ -104,7 +104,7 @@ void monio::Monio::readIncrements(atlas::FieldSet& localFieldSet,
         reader_.openFile(fileData);
         reader_.readMetadata(fileData);
         std::vector<std::string> meshVars =
-            fileData.getMetadata().findVariableNames(std::string(monio::consts::kLfricMeshTerm));
+            fileData.getMetadata().findVariableNames(std::string(consts::kLfricMeshTerm));
         reader_.readFullData(fileData, meshVars);
         createLfricAtlasMap(fileData, grid);
       }


### PR DESCRIPTION
This PR introduces the equivalent fix as in LFRic-Lite's recent bugfix: https://github.com/JCSDA-internal/lfric-lite-jedi/pull/316

Also simplifies the use of constants by dropping the namespace prefix where applicable (this is why a larger number of files are impacted by this PR than strictly necessary).

Current testing outputs: http://fcm1/cylc-review/taskjobs/punderwo/?suite=monio_dbl_attr_02