### PR TITLE
Standardise Throw Runtime Error

### DIFF
--- a/src/monio/AtlasProcessor.cc
+++ b/src/monio/AtlasProcessor.cc
@@ -19,6 +19,7 @@
 
 #include "AttributeString.h"
 #include "Metadata.h"
+#include "Utils.h"
 #include "Writer.h"
 
 monio::AtlasProcessor::AtlasProcessor(const eckit::mpi::Comm& mpiCommunicator,
@@ -46,7 +47,7 @@ std::vector<atlas::PointLonLat> monio::AtlasProcessor::getLfricCoords(
           coordVectorArray[coordCount] = coordData;
           coordCount++;
         } else {
-          throw std::runtime_error("AtlasProcessor::getLfricCoords()> "
+          utils::throwException("AtlasProcessor::getLfricCoords()> "
               "Data type not coded for...");
         }
       }
@@ -57,7 +58,7 @@ std::vector<atlas::PointLonLat> monio::AtlasProcessor::getLfricCoords(
         lfricCoords.push_back(atlas::PointLonLat(*lonIt, *latIt));
       }
     } else {
-        throw std::runtime_error("AtlasProcessor::getLfricCoords()> "
+        utils::throwException("AtlasProcessor::getLfricCoords()> "
             "Incorrect number of coordinate axes...");
     }
   }
@@ -102,7 +103,7 @@ std::vector<size_t> monio::AtlasProcessor::createLfricAtlasMap(
   if (mpiCommunicator_.rank() == mpiRankOwner_) {
     // Essential check to ensure grid is configured to accommodate the data
     if (atlasCoords.size() != lfricCoords.size()) {
-      throw std::runtime_error("AtlasProcessor::createLfricAtlasMap()> "
+      utils::throwException("AtlasProcessor::createLfricAtlasMap()> "
         "Configured grid is not compatible with input file...");
     }
     lfricAtlasMap.reserve(atlasCoords.size());
@@ -148,7 +149,7 @@ atlas::Field monio::AtlasProcessor::getGlobalField(const atlas::Field& field) {
         globalField = functionSpace.createField<int>(atlasOptions);
         break;
       default:
-        throw std::runtime_error("AtlasProcessor::getGlobalFieldSet())> "
+        utils::throwException("AtlasProcessor::getGlobalFieldSet())> "
                                  "Data type not coded for...");
     }
     field.haloExchange();
@@ -168,7 +169,7 @@ atlas::FieldSet monio::AtlasProcessor::getGlobalFieldSet(const atlas::FieldSet& 
     }
     return globalFieldSet;
   } else {
-    throw std::runtime_error("AtlasProcessor::getGlobalFieldSet()> FieldSet has zero fields...");
+    utils::throwException("AtlasProcessor::getGlobalFieldSet()> FieldSet has zero fields...");
   }
 }
 

--- a/src/monio/AtlasReader.cc
+++ b/src/monio/AtlasReader.cc
@@ -10,6 +10,8 @@
 
 #include "oops/util/Logger.h"
 
+#include "Utils.h"
+
 monio::AtlasReader::AtlasReader(const eckit::mpi::Comm& mpiCommunicator,
                                     const atlas::idx_t mpiRankOwner):
     mpiCommunicator_(mpiCommunicator),
@@ -45,7 +47,7 @@ void monio::AtlasReader::populateFieldWithDataContainer(atlas::Field& field,
       break;
     }
     default:
-      throw std::runtime_error("AtlasReader::populateFieldWithDataContainer()> "
+      utils::throwException("AtlasReader::populateFieldWithDataContainer()> "
                                "Data type not coded for...");
     }
   }
@@ -76,7 +78,7 @@ void monio::AtlasReader::populateFieldWithDataContainer(atlas::Field& field,
       break;
     }
     default:
-      throw std::runtime_error("AtlasReader::populateFieldWithDataContainer()> "
+      utils::throwException("AtlasReader::populateFieldWithDataContainer()> "
                                "Data type not coded for...");
     }
   }
@@ -123,7 +125,7 @@ void monio::AtlasReader::populateField(atlas::Field& field,
       if (std::size_t(index) <= dataVec.size()) {
         fieldView(i, j) = dataVec[index];
       } else {
-        throw std::runtime_error("Calculated index exceeds size of data for field \""
+        utils::throwException("Calculated index exceeds size of data for field \""
                                  + field.name() + "\".");
       }
     }
@@ -160,7 +162,7 @@ void monio::AtlasReader::populateField(atlas::Field& field,
       if (std::size_t(index) <= dataVec.size()) {
         fieldView(i, j) = dataVec[index];
       } else {
-        throw std::runtime_error("Calculated index exceeds size of data.");
+        utils::throwException("Calculated index exceeds size of data.");
       }
     }
   }

--- a/src/monio/AtlasWriter.cc
+++ b/src/monio/AtlasWriter.cc
@@ -13,6 +13,7 @@
 #include "oops/util/Logger.h"
 
 #include "Metadata.h"
+#include "Utils.h"
 #include "Writer.h"
 
 namespace {
@@ -191,7 +192,7 @@ void monio::AtlasWriter::populateDataContainerWithField(
       break;
     }
     default:
-      throw std::runtime_error("AtlasWriter::populateDataContainerWithField()> "
+      utils::throwException("AtlasWriter::populateDataContainerWithField()> "
                                "Data type not coded for...");
     }
   }
@@ -241,7 +242,7 @@ void monio::AtlasWriter::populateDataContainerWithField(
       break;
     }
     default:
-      throw std::runtime_error("AtlasWriter::populateDataContainerWithField()> "
+      utils::throwException("AtlasWriter::populateDataContainerWithField()> "
                                "Data type not coded for...");
     }
   }
@@ -254,7 +255,7 @@ void monio::AtlasWriter::populateDataVec(std::vector<T>& dataVec,
   oops::Log::debug() << "AtlasWriter::populateDataVec() " << field.name() << std::endl;
   atlas::idx_t numLevels = field.levels();
   if ((lfricToAtlasMap.size() * numLevels) != dataVec.size()) {
-    throw std::runtime_error("AtlasWriter::populateDataVec()> "
+    utils::throwException("AtlasWriter::populateDataVec()> "
                              "Data container is not configured for the expected data...");
   }
   auto fieldView = atlas::array::make_view<T, 2>(field);
@@ -506,6 +507,6 @@ int monio::AtlasWriter::atlasTypeToMonioEnum(atlas::array::DataType atlasType) {
     return consts::eDouble;
   }
   default:
-    throw std::runtime_error("AtlasWriter::fromFieldSet()> Data type not coded for...");
+    utils::throwException("AtlasWriter::fromFieldSet()> Data type not coded for...");
   }
 }

--- a/src/monio/AttributeDouble.h
+++ b/src/monio/AttributeDouble.h
@@ -11,7 +11,7 @@
 #include "AttributeBase.h"
 
 namespace monio {
-/// \brief Concrete class for integer attributes of a NetCDF file
+/// \brief Concrete class for double attributes of a NetCDF file
 class AttributeDouble : public AttributeBase {
  public:
   AttributeDouble(const std::string& name, const double value);

--- a/src/monio/Data.cc
+++ b/src/monio/Data.cc
@@ -113,7 +113,7 @@ void monio::Data::deleteContainer(const std::string& name) {
   if (it != dataContainers_.end()) {
     dataContainers_.erase(name);
   } else {
-    throw std::runtime_error("DataContainer named \"" + name + "\" was not found.");
+    utils::throwException("DataContainer named \"" + name + "\" was not found.");
   }
 }
 
@@ -144,7 +144,7 @@ std::shared_ptr<monio::DataContainerBase>
   if (it != dataContainers_.end()) {
     return it->second;
   } else {
-    throw std::runtime_error("DataContainer named \"" + name + "\" was not found.");
+    utils::throwException("DataContainer named \"" + name + "\" was not found.");
   }
 }
 

--- a/src/monio/DataContainerDouble.cc
+++ b/src/monio/DataContainerDouble.cc
@@ -11,6 +11,7 @@
 #include <stdexcept>
 
 #include "Constants.h"
+#include "Utils.h"
 
 monio::DataContainerDouble::DataContainerDouble(const std::string& name) :
   DataContainerBase(name, consts::eDouble) {}
@@ -33,7 +34,7 @@ const double* monio::DataContainerDouble::getDataPointer() {
 
 const double& monio::DataContainerDouble::getDatum(const size_t index) {
   if (index > dataVector_.size())
-    throw std::runtime_error("DataContainerDouble::getDatum()> "
+    utils::throwException("DataContainerDouble::getDatum()> "
         "Passed index exceeds vector size...");
 
   return dataVector_[index];

--- a/src/monio/DataContainerFloat.cc
+++ b/src/monio/DataContainerFloat.cc
@@ -11,6 +11,7 @@
 #include <stdexcept>
 
 #include "Constants.h"
+#include "Utils.h"
 
 monio::DataContainerFloat::DataContainerFloat(const std::string& name) :
   DataContainerBase(name, consts::eFloat) {}
@@ -33,7 +34,7 @@ const float* monio::DataContainerFloat::getDataPointer() {
 
 const float& monio::DataContainerFloat::getDatum(const size_t index) {
   if (index > dataVector_.size())
-    throw std::runtime_error("DataContainerFloat::getDatum()> "
+    utils::throwException("DataContainerFloat::getDatum()> "
         "Passed index exceeds vector size...");
 
   return dataVector_[index];

--- a/src/monio/DataContainerInt.cc
+++ b/src/monio/DataContainerInt.cc
@@ -11,6 +11,7 @@
 #include <stdexcept>
 
 #include "Constants.h"
+#include "Utils.h"
 
 monio::DataContainerInt::DataContainerInt(const std::string& name) :
   DataContainerBase(name, consts::eInt) {}
@@ -33,7 +34,7 @@ const int* monio::DataContainerInt::getDataPointer() {
 
 const int& monio::DataContainerInt::getDatum(const size_t index) {
   if (index > dataVector_.size())
-    throw std::runtime_error("DataContainerInt::getDatum()> "
+    utils::throwException("DataContainerInt::getDatum()> "
         "Passed index exceeds vector size...");
 
   return dataVector_[index];

--- a/src/monio/File.cc
+++ b/src/monio/File.cc
@@ -21,6 +21,7 @@
 #include "AttributeInt.h"
 #include "AttributeString.h"
 #include "Constants.h"
+#include "Utils.h"
 #include "Variable.h"
 
 // De/Constructors ////////////////////////////////////////////////////////////////////////////////
@@ -36,7 +37,7 @@ monio::File::File(const std::string& filePath,
   } catch (netCDF::exceptions::NcException& exception) {
     std::string message = "An exception occurred in File> ";
     message.append(exception.what());
-    throw std::runtime_error(message);
+    utils::throwException(message);
   }
 }
 
@@ -60,7 +61,7 @@ void monio::File::readMetadata(Metadata& metadata) {
     readAttributes(metadata);  // Global attributes
     metadata.print();
   } else {
-    throw std::runtime_error(
+    utils::throwException(
         "File::readMetadata()> Write file accessed for reading...");
   }
 }
@@ -74,7 +75,7 @@ void monio::File::readMetadata(Metadata& metadata,
     readAttributes(metadata);  // Global attributes
     metadata.print();
   } else {
-    throw std::runtime_error(
+    utils::throwException(
         "File::readMetadata()> Write file accessed for reading...");
   }
 }
@@ -88,7 +89,7 @@ void monio::File::readDimensions(Metadata& metadata) {
       metadata.addDimension(ncDimPair.first, value);
     }
   } else {
-    throw std::runtime_error(
+    utils::throwException(
         "File::readDimensions()> Write file accessed for reading...");
   }
 }
@@ -103,7 +104,7 @@ void monio::File::readVariables(Metadata& metadata) {
       readVariable(metadata, ncVar);
     }
   } else {
-    throw std::runtime_error("File::readVariables()> Write file accessed for reading...");
+    utils::throwException("File::readVariables()> Write file accessed for reading...");
   }
 }
 
@@ -121,7 +122,7 @@ void monio::File::readVariables(Metadata& metadata,
       }
     }
   } else {
-    throw std::runtime_error("File::readVariables()> Write file accessed for reading...");
+    utils::throwException("File::readVariables()> Write file accessed for reading...");
   }
 }
 
@@ -144,14 +145,14 @@ void monio::File::readVariable(Metadata& metadata, netCDF::NcVar ncVar) {
       break;
     }
     default:
-      throw std::runtime_error("File::readVariable()> Variable data type " +
+      utils::throwException("File::readVariable()> Variable data type " +
                                   varType.getName() + " not coded for.");
   }
   std::vector<netCDF::NcDim> ncVarDims = ncVar.getDims();
   for (auto const& ncVarDim : ncVarDims) {
     std::string varDimName = ncVarDim.getName();
     if (metadata.isDimDefined(varDimName) == false) {
-      throw std::runtime_error("File::readVariable()> Variable dimension \"" +
+      utils::throwException("File::readVariable()> Variable dimension \"" +
                                varDimName + "\" not defined.");
     }
     std::size_t varDimSize = ncVarDim.getSize();
@@ -192,7 +193,7 @@ void monio::File::readVariable(Metadata& metadata, netCDF::NcVar ncVar) {
         break;
       }
       default:
-        throw std::runtime_error("File::readVariable()> Variable attribute data type \""
+        utils::throwException("File::readVariable()> Variable attribute data type \""
                                     + ncVarAttrType.getName() + "\" not coded for.");
     }
   }
@@ -232,13 +233,13 @@ void monio::File::readAttributes(Metadata& metadata) {
           break;
         }
         default:
-          throw std::runtime_error("File::readAttributes()> Global attribute data type \""
+          utils::throwException("File::readAttributes()> Global attribute data type \""
                                    + attrType.getName() + "\" not coded for.");
       }
       metadata.addGlobalAttr(globAttr->getName(), globAttr);
     }
   } else {
-    throw std::runtime_error(
+    utils::throwException(
         "File::readAttributes()> Write file accessed for reading...");
   }
 }
@@ -253,7 +254,7 @@ void monio::File::readSingleDatum(const std::string& varName,
     dataVec.resize(varSize, 0);
     var.getVar(dataVec.data());
   } else {
-    throw std::runtime_error("File::readSingleDatum()> Write file accessed for reading...");
+    utils::throwException("File::readSingleDatum()> Write file accessed for reading...");
   }
 }
 
@@ -279,7 +280,7 @@ void monio::File::readFieldDatum(const std::string& fieldName,
     dataVec.resize(varSize, 0);
     var.getVar(startVec, countVec, dataVec.data());
   } else {
-    throw std::runtime_error("File::readFieldDatum()> Write file accessed for reading...");
+    utils::throwException("File::readFieldDatum()> Write file accessed for reading...");
   }
 }
 
@@ -308,7 +309,7 @@ void monio::File::writeMetadata(const Metadata& metadata) {
     writeVariables(metadata);
     writeAttributes(metadata);  // Global attributes
   } else {
-    throw std::runtime_error(
+    utils::throwException(
         "File::writeMetadata()> Read file accessed for writing...");
   }
 }
@@ -321,7 +322,7 @@ void monio::File::writeDimensions(const Metadata& metadata) {
       getFile().addDim(dimPair.first, dimPair.second);
     }
   } else {
-    throw std::runtime_error("File::writeDimensions()> Read file accessed for writing...");
+    utils::throwException("File::writeDimensions()> Read file accessed for writing...");
   }
 }
 
@@ -359,13 +360,13 @@ void monio::File::writeVariables(const Metadata& metadata) {
             break;
           }
           default:
-            throw std::runtime_error("File::writeVariables()> "
+            utils::throwException("File::writeVariables()> "
                 "Variable attribute data type not coded for...");
         }
       }
     }
   } else {
-    throw std::runtime_error("File::writeVariables()> Read file accessed for writing...");
+    utils::throwException("File::writeVariables()> Read file accessed for writing...");
   }
 }
 
@@ -398,12 +399,12 @@ void monio::File::writeAttributes(const Metadata& metadata) {
           break;
         }
         default:
-          throw std::runtime_error("File::writeAttributes()> "
+          utils::throwException("File::writeAttributes()> "
               "Variable attribute data type not coded for...");
       }
     }
   } else {
-    throw std::runtime_error("File::writeAttributes()> Read file accessed for writing...");
+    utils::throwException("File::writeAttributes()> Read file accessed for writing...");
   }
 }
 
@@ -414,7 +415,7 @@ void monio::File::writeSingleDatum(const std::string &varName, const std::vector
     auto var = getFile().getVar(varName);
     var.putVar(dataVec.data());
   } else {
-    throw std::runtime_error("File::writeSingleDatum()> Read file accessed for writing...");
+    utils::throwException("File::writeSingleDatum()> Read file accessed for writing...");
   }
 }
 
@@ -453,7 +454,7 @@ bool monio::File::isWrite() {
 
 netCDF::NcFile& monio::File::getFile() {
   if (dataFile_ == nullptr)
-    throw std::runtime_error("File::getFile()> Data file has not been initialised...");
+    utils::throwException("File::getFile()> Data file has not been initialised...");
 
   return *dataFile_;
 }

--- a/src/monio/Metadata.cc
+++ b/src/monio/Metadata.cc
@@ -141,7 +141,7 @@ int monio::Metadata::getDimension(const std::string& dimName) {
   if (isDimDefined(dimName) == true)
     return dimensions_.at(dimName);
   else
-    throw std::runtime_error("Metadata::getDimension()> dimension \"" +
+    utils::throwException("Metadata::getDimension()> dimension \"" +
                                 dimName + "\" not found...");
 }
 
@@ -160,7 +160,7 @@ std::shared_ptr<monio::Variable> monio::Metadata::getVariable(const std::string&
   if (it != variables_.end())
     return variables_.at(varName);
   else
-    throw std::runtime_error("Metadata::getVariable()> variable \"" +
+    utils::throwException("Metadata::getVariable()> variable \"" +
                                 varName + "\" not found...");
 }
 
@@ -172,7 +172,7 @@ const std::shared_ptr<monio::Variable>
   if (it != variables_.end())
     return variables_.at(varName);
   else
-    throw std::runtime_error("Metadata::getVariable()> variable \"" +
+    utils::throwException("Metadata::getVariable()> variable \"" +
                                 varName + "\" not found...");
 }
 
@@ -213,7 +213,7 @@ const std::vector<std::string> monio::Metadata::getVarStrAttrs(
       varStrAttrs.push_back(attr);
   }
   if (varNames.size() != varStrAttrs.size())
-    throw std::runtime_error("Metadata::getVarStrAttrs()> "
+    utils::throwException("Metadata::getVarStrAttrs()> "
         "Unmatched number of variables and attributes...");
 
   return varStrAttrs;
@@ -350,7 +350,7 @@ void monio::Metadata::deleteVariable(const std::string& varName) {
   if (it != variables_.end()) {
     variables_.erase(varName);
   } else {
-    throw std::runtime_error("Metadata::deleteVariable()> Variable \"" +
+    utils::throwException("Metadata::deleteVariable()> Variable \"" +
                              varName + "\" not found...");
   }
 }
@@ -418,7 +418,7 @@ void monio::Metadata::printVariables() {
           break;
         }
         default:
-          throw std::runtime_error("Metadata::printGlobalAttrs()> "
+          utils::throwException("Metadata::printGlobalAttrs()> "
                                    "Data type not coded for...");
       }
     }
@@ -450,7 +450,7 @@ void monio::Metadata::printGlobalAttrs() {
         break;
       }
       default:
-        throw std::runtime_error("Metadata::printGlobalAttrs()> Data type not coded for...");
+        utils::throwException("Metadata::printGlobalAttrs()> Data type not coded for...");
     }
   }
 }

--- a/src/monio/Monio.cc
+++ b/src/monio/Monio.cc
@@ -38,7 +38,7 @@ void monio::Monio::readBackground(atlas::FieldSet& localFieldSet,
                             const util::DateTime& dateTime) {
   oops::Log::debug() << "Monio::readBackground()" << std::endl;
   if (localFieldSet.size() == 0) {
-    throw std::runtime_error("Monio::readBackground()> localFieldSet has zero fields...");
+    utils::throwException("Monio::readBackground()> localFieldSet has zero fields...");
   }
   for (const auto& fieldMetadata : fieldMetadataVec) {
     auto& localField = localFieldSet[fieldMetadata.jediName];
@@ -87,7 +87,7 @@ void monio::Monio::readIncrements(atlas::FieldSet& localFieldSet,
                             const std::string& filePath) {
   oops::Log::debug() << "Monio::readIncrements()" << std::endl;
   if (localFieldSet.size() == 0) {
-    throw std::runtime_error("Monio::readIncrements()> localFieldSet has zero fields...");
+    utils::throwException("Monio::readIncrements()> localFieldSet has zero fields...");
   }
   for (const auto& fieldMetadata : fieldMetadataVec) {
     auto& localField = localFieldSet[fieldMetadata.jediName];
@@ -129,7 +129,7 @@ void monio::Monio::writeIncrements(const atlas::FieldSet& localFieldSet,
                                    const bool isLfricFormat) {
   oops::Log::debug() << "Monio::writeIncrements()" << std::endl;
   if (localFieldSet.size() == 0) {
-    throw std::runtime_error("Monio::writeIncrements()> localFieldSet has zero fields...");
+    utils::throwException("Monio::writeIncrements()> localFieldSet has zero fields...");
   }
   atlas::FieldSet globalFieldSet = atlasProcessor_.getGlobalFieldSet(localFieldSet);
   if (mpiCommunicator_.rank() == mpiRankOwner_) {
@@ -182,7 +182,7 @@ void monio::Monio::createDateTimes(FileData& fileData,
       std::shared_ptr<DataContainerBase> timeDataBase =
                                              fileData.getData().getContainer(timeVarName);
       if (timeDataBase->getType() != consts::eDouble)
-        throw std::runtime_error("Monio::createDateTimes()> "
+        utils::throwException("Monio::createDateTimes()> "
                                  "Time data not stored as double...");
 
       std::shared_ptr<DataContainerDouble> timeData =
@@ -240,7 +240,7 @@ monio::FileData monio::Monio::getFileData(const std::string& gridName) {
   if (it != filesData_.end()) {
     return FileData(it->second);
   }
-  throw std::runtime_error("Monio::getFileData()> FileData with grid name \"" +
+  utils::throwException("Monio::getFileData()> FileData with grid name \"" +
                            gridName + "\" not found...");
 }
 

--- a/src/monio/Reader.cc
+++ b/src/monio/Reader.cc
@@ -18,6 +18,7 @@
 #include "DataContainerDouble.h"
 #include "DataContainerFloat.h"
 #include "DataContainerInt.h"
+#include "Utils.h"
 #include "Variable.h"
 
 #include "oops/util/Duration.h"
@@ -59,7 +60,7 @@ void monio::Reader::openFile(const FileData& fileData) {
         std::string message =
             "Reader::openFile()> An exception occurred while creating File...";
         message.append(exception.what());
-        throw std::runtime_error(message);
+        utils::throwException(message);
       }
     }
   }
@@ -167,12 +168,12 @@ void monio::Reader::readDatumAtTime(FileData& fileData,
           break;
         }
         default:
-          throw std::runtime_error("Reader::readFieldData()> Data type not coded for...");
+          utils::throwException("Reader::readFieldData()> Data type not coded for...");
       }
       if (dataContainer != nullptr)
         fileData.getData().addContainer(dataContainer);
       else
-        throw std::runtime_error("Reader::readFieldData()> "
+        utils::throwException("Reader::readFieldData()> "
            "An exception occurred while creating data container...");
     } else {
       oops::Log::debug() << "Reader::readFieldDatum()> DataContainer \""
@@ -224,13 +225,13 @@ void monio::Reader::readFullDatum(FileData& fileData,
         break;
       }
       default:
-        throw std::runtime_error("Reader::readVariable()> Data type not coded for...");
+        utils::throwException("Reader::readVariable()> Data type not coded for...");
     }
 
     if (dataContainer != nullptr)
       fileData.getData().addContainer(dataContainer);
     else
-      throw std::runtime_error("Reader::readVariable()> "
+      utils::throwException("Reader::readVariable()> "
           "An exception occurred while creating data container...");
   }
 }
@@ -238,7 +239,7 @@ void monio::Reader::readFullDatum(FileData& fileData,
 monio::File& monio::Reader::getFile() {
   oops::Log::debug() << "Reader::getFile()" << std::endl;
   if (file_ == nullptr)
-    throw std::runtime_error("Reader::getFile()> File has not been initialised...");
+    utils::throwException("Reader::getFile()> File has not been initialised...");
 
   return *file_;
 }
@@ -272,7 +273,7 @@ std::vector<std::shared_ptr<monio::DataContainerBase>> monio::Reader::getCoordDa
     }
     return coordContainers;
   } else {
-      throw std::runtime_error("Reader::getCoordData()> Incorrect number of coordinate axes...");
+      utils::throwException("Reader::getCoordData()> Incorrect number of coordinate axes...");
   }
 }
 
@@ -302,12 +303,12 @@ size_t monio::Reader::findTimeStep(const FileData& fileData, const util::DateTim
   oops::Log::debug() << "Reader::findTimeStep()" << std::endl;
   if (fileData.getDateTimes().size() == 0) {
     oops::Log::debug() << "Reader::findTimeStep()> Date times not initialised..." << std::endl;
-    throw std::runtime_error("Reader::findTimeStep()> Date times not initialised...");
+    utils::throwException("Reader::findTimeStep()> Date times not initialised...");
   }
 
   for (size_t timeStep = 0; timeStep < fileData.getDateTimes().size(); ++timeStep) {
     if (fileData.getDateTimes()[timeStep] == dateTime)
       return timeStep;
   }
-  throw std::runtime_error("Reader::findTimeStep()> DateTime specified not located in file...");
+  utils::throwException("Reader::findTimeStep()> DateTime specified not located in file...");
 }

--- a/src/monio/Utils.cc
+++ b/src/monio/Utils.cc
@@ -15,6 +15,8 @@
 #include "DataContainerBase.h"
 #include "Variable.h"
 
+#include "oops/util/Logger.h"
+
 namespace monio {
 namespace utils {
 std::vector<std::string> strToWords(const std::string inputStr,
@@ -97,5 +99,10 @@ bool findInVector(std::vector<T> vector, T searchTerm) {
 }
 
 template bool findInVector<std::string>(std::vector<std::string> vector, std::string searchTerm);
+
+void throwException(const std::string message) {
+  oops::Log::debug() << message << std::endl;
+  throw std::runtime_error(message);
+}
 }  // namespace utils
 }  // namespace monio

--- a/src/monio/Utils.h
+++ b/src/monio/Utils.h
@@ -33,5 +33,7 @@ namespace utils {
 
   template<typename T>
   bool findInVector(std::vector<T> vector, T searchTerm);
+
+  [[noreturn]] void throwException(const std::string message);
 }  // namespace utils
 }  // namespace monio

--- a/src/monio/Variable.cc
+++ b/src/monio/Variable.cc
@@ -67,7 +67,7 @@ std::shared_ptr<monio::AttributeBase>
   if (attributes_.find(attrName) != attributes_.end()) {
     return attributes_.at(attrName);
   } else {
-    throw std::runtime_error("Variable::getAttribute()> Attribute \"" +
+    utils::throwException("Variable::getAttribute()> Attribute \"" +
                                     attrName + "\" not found...");
   }
 }
@@ -86,11 +86,11 @@ std::string monio::Variable::getStrAttr(const std::string& attrName) {
       // Does not currently handle AttributeInt types. Used specifically to retrieve LFRic's
       // "standard_type" variable attributes as the closest approximation to a JEDI variable name.
       // These are stored as AttributeString.
-      throw std::runtime_error("Variable::getAttribute()> "
+      utils::throwException("Variable::getAttribute()> "
           "Variable attribute data type not coded for...");
     }
   } else {
-    throw std::runtime_error("Variable::getAttribute()> Attribute \"" +
+    utils::throwException("Variable::getAttribute()> Attribute \"" +
                                     attrName + "\" not found...");
   }
 }
@@ -102,7 +102,7 @@ void monio::Variable::addDimension(const std::string& dimName, const size_t size
   if (it == dimensions_.end()) {
     dimensions_.push_back(std::make_pair(dimName, size));
   } else {
-      throw std::runtime_error("Variable::addDimension()> Dimension \"" +
+      utils::throwException("Variable::addDimension()> Dimension \"" +
                                     dimName + "\" already defined...");
   }
 }
@@ -113,7 +113,7 @@ void monio::Variable::addAttribute(std::shared_ptr<monio::AttributeBase> attr) {
   if (it == attributes_.end()) {
     attributes_.insert(std::make_pair(attrName, attr));
   } else {
-    throw std::runtime_error("Variable::addAttribute()>  multiple definitions of \"" +
+    utils::throwException("Variable::addAttribute()>  multiple definitions of \"" +
                                 attrName + "\"...");
   }
 }
@@ -133,7 +133,7 @@ void monio::Variable::deleteAttribute(const std::string& attrName) {
   if (it != attributes_.end()) {
     attributes_.erase(attrName);
   } else {
-      throw std::runtime_error("Variable::deleteAttribute()> Attribute \"" +
+      utils::throwException("Variable::deleteAttribute()> Attribute \"" +
                                     attrName + "\" does not exist...");
   }
 }
@@ -146,7 +146,7 @@ size_t monio::Variable::getDimension(const std::string& dimName) {
   if (it != dimensions_.end()) {
     return it->second;
   } else {
-      throw std::runtime_error("Variable::getDimension()> Dimension \"" +
+      utils::throwException("Variable::getDimension()> Dimension \"" +
                                     dimName + "\" does not exist...");
   }
 }

--- a/src/monio/Writer.cc
+++ b/src/monio/Writer.cc
@@ -16,6 +16,7 @@
 #include "DataContainerDouble.h"
 #include "DataContainerFloat.h"
 #include "DataContainerInt.h"
+#include "Utils.h"
 
 #include "oops/util/Logger.h"
 
@@ -32,7 +33,7 @@ monio::Writer::Writer(const eckit::mpi::Comm& mpiCommunicator,
       std::string message =
           "Writer::Writer()> An exception occurred while creating File...";
       message.append(exception.what());
-      throw std::runtime_error(message);
+      utils::throwException(message);
     }
   }
 }
@@ -80,7 +81,7 @@ void monio::Writer::writeVariablesData(const Metadata& metadata, const Data& dat
         break;
       }
       default:
-        throw std::runtime_error("Writer::writeVariablesData()> Data type not coded for...");
+        utils::throwException("Writer::writeVariablesData()> Data type not coded for...");
       }
     }
   }
@@ -89,7 +90,7 @@ void monio::Writer::writeVariablesData(const Metadata& metadata, const Data& dat
 monio::File& monio::Writer::getFile() {
   oops::Log::debug() << "Writer::getFile()" << std::endl;
   if (file_ == nullptr)
-    throw std::runtime_error("Writer::getFile()> File has not been initialised...");
+    utils::throwException("Writer::getFile()> File has not been initialised...");
 
   return *file_;
 }


### PR DESCRIPTION
Added utility function to standardise the way runtime errors are thrown and logged. It's not essential, but was introduced to help track down the source of a bug, and the decision was made to roll it out to all places that throw runtime errors.

Current test outputs: http://fcm1/cylc-review/taskjobs/punderwo/?suite=monio_throw_exception