### PR TITLE
Feature/reader and writer

### DIFF
--- a/src/monio/AtlasReader.cc
+++ b/src/monio/AtlasReader.cc
@@ -20,6 +20,29 @@ monio::AtlasReader::AtlasReader(const eckit::mpi::Comm& mpiCommunicator,
   oops::Log::debug() << "AtlasReader::AtlasReader()" << std::endl;
 }
 
+void monio::AtlasReader::populateFieldSetWithData(atlas::FieldSet& fieldSet,
+                                                  const Data& data) {
+  oops::Log::debug() << "AtlasReader::populateFieldSetWithData()" << std::endl;
+  if (mpiCommunicator_.rank() == mpiRankOwner_) {
+    for (auto& field : fieldSet) {
+      populateFieldWithDataContainer(field, data.getContainer(field.name()));
+    }
+  }
+}
+
+void monio::AtlasReader::populateFieldSetWithData(atlas::FieldSet& fieldSet,
+                                                  const Data& data,
+                                                  const std::vector<std::string>& fieldNames) {
+  oops::Log::debug() << "AtlasReader::populateFieldSetWithData()" << std::endl;
+  if (mpiCommunicator_.rank() == mpiRankOwner_) {
+    auto fieldNameIt = fieldNames.begin();
+    for (auto& field : fieldSet) {
+      populateFieldWithDataContainer(field, data.getContainer(*fieldNameIt));
+      ++fieldNameIt;
+    }
+  }
+}
+
 void monio::AtlasReader::populateFieldWithDataContainer(atlas::Field& field,
                                       const std::shared_ptr<DataContainerBase>& dataContainer,
                                       const std::vector<size_t>& lfricToAtlasMap,
@@ -83,30 +106,6 @@ void monio::AtlasReader::populateFieldWithDataContainer(atlas::Field& field,
     }
   }
 }
-
-void monio::AtlasReader::populateFieldSetWithData(atlas::FieldSet& fieldSet,
-                                                  const Data& data) {
-  oops::Log::debug() << "AtlasReader::populateFieldSetWithData()" << std::endl;
-  if (mpiCommunicator_.rank() == mpiRankOwner_) {
-    for (auto& field : fieldSet) {
-      populateFieldWithDataContainer(field, data.getContainer(field.name()));
-    }
-  }
-}
-
-void monio::AtlasReader::populateFieldSetWithData(atlas::FieldSet& fieldSet,
-                                                  const Data& data,
-                                                  const std::vector<std::string>& fieldNames) {
-  oops::Log::debug() << "AtlasReader::populateFieldSetWithData()" << std::endl;
-  if (mpiCommunicator_.rank() == mpiRankOwner_) {
-    auto fieldNameIt = fieldNames.begin();
-    for (auto& field : fieldSet) {
-      populateFieldWithDataContainer(field, data.getContainer(*fieldNameIt));
-      ++fieldNameIt;
-    }
-  }
-}
-
 
 template<typename T>
 void monio::AtlasReader::populateField(atlas::Field& field,

--- a/src/monio/AtlasReader.cc
+++ b/src/monio/AtlasReader.cc
@@ -20,29 +20,6 @@ monio::AtlasReader::AtlasReader(const eckit::mpi::Comm& mpiCommunicator,
   oops::Log::debug() << "AtlasReader::AtlasReader()" << std::endl;
 }
 
-void monio::AtlasReader::populateFieldSetWithData(atlas::FieldSet& fieldSet,
-                                                  const Data& data) {
-  oops::Log::debug() << "AtlasReader::populateFieldSetWithData()" << std::endl;
-  if (mpiCommunicator_.rank() == mpiRankOwner_) {
-    for (auto& field : fieldSet) {
-      populateFieldWithDataContainer(field, data.getContainer(field.name()));
-    }
-  }
-}
-
-void monio::AtlasReader::populateFieldSetWithData(atlas::FieldSet& fieldSet,
-                                                  const Data& data,
-                                                  const std::vector<std::string>& fieldNames) {
-  oops::Log::debug() << "AtlasReader::populateFieldSetWithData()" << std::endl;
-  if (mpiCommunicator_.rank() == mpiRankOwner_) {
-    auto fieldNameIt = fieldNames.begin();
-    for (auto& field : fieldSet) {
-      populateFieldWithDataContainer(field, data.getContainer(*fieldNameIt));
-      ++fieldNameIt;
-    }
-  }
-}
-
 void monio::AtlasReader::populateFieldWithDataContainer(atlas::Field& field,
                                       const std::shared_ptr<DataContainerBase>& dataContainer,
                                       const std::vector<size_t>& lfricToAtlasMap,

--- a/src/monio/AtlasReader.h
+++ b/src/monio/AtlasReader.h
@@ -40,6 +40,11 @@ class AtlasReader {
   AtlasReader& operator=( AtlasReader&&)      = delete;  //!< Deleted move assignment
   AtlasReader& operator=(const AtlasReader&)  = delete;  //!< Deleted copy assignment
 
+  void populateFieldSetWithData(atlas::FieldSet& fieldSet, const Data& data);
+  void populateFieldSetWithData(atlas::FieldSet& fieldSet,
+                          const Data& data,
+                          const std::vector<std::string>& fieldNames);
+
   void populateFieldWithDataContainer(atlas::Field& field,
                                 const std::shared_ptr<monio::DataContainerBase>& dataContainer,
                                 const std::vector<size_t>& lfricToAtlasMap,
@@ -48,13 +53,7 @@ class AtlasReader {
   void populateFieldWithDataContainer(atlas::Field& field,
                                 const std::shared_ptr<monio::DataContainerBase>& dataContainer);
 
-  void populateFieldSetWithData(atlas::FieldSet& fieldSet, const Data& data);
-  void populateFieldSetWithData(atlas::FieldSet& fieldSet,
-                          const Data& data,
-                          const std::vector<std::string>& fieldNames);
-
  private:
-  // AtlasWriter::populateFieldWithDataContainer
   template<typename T> void populateField(atlas::Field& field,
                                     const std::vector<T>& dataVec,
                                     const std::vector<size_t>& lfricToAtlasMap,

--- a/src/monio/AtlasReader.h
+++ b/src/monio/AtlasReader.h
@@ -40,15 +40,10 @@ class AtlasReader {
   AtlasReader& operator=( AtlasReader&&)      = delete;  //!< Deleted move assignment
   AtlasReader& operator=(const AtlasReader&)  = delete;  //!< Deleted copy assignment
 
-  void populateFieldSetWithData(atlas::FieldSet& fieldSet, const Data& data);
-  void populateFieldSetWithData(atlas::FieldSet& fieldSet,
-                          const Data& data,
-                          const std::vector<std::string>& fieldNames);
-
   void populateFieldWithDataContainer(atlas::Field& field,
                                 const std::shared_ptr<monio::DataContainerBase>& dataContainer,
                                 const std::vector<size_t>& lfricToAtlasMap,
-                                const bool copyFirstLevel = false);  // Monio::readBackground
+                                const bool copyFirstLevel = false);
 
   void populateFieldWithDataContainer(atlas::Field& field,
                                 const std::shared_ptr<monio::DataContainerBase>& dataContainer);

--- a/src/monio/AtlasWriter.cc
+++ b/src/monio/AtlasWriter.cc
@@ -242,11 +242,12 @@ template void monio::AtlasWriter::populateDataVec<int>(std::vector<int>& dataVec
                                                        const atlas::Field& field,
                                                        const std::vector<int>& dimensions);
 
-void monio::AtlasWriter::populateMetadataAndDataWithFieldSet(Metadata& metadata,
-                                                             Data& data,
-                                                       const atlas::FieldSet& fieldSet) {
+void monio::AtlasWriter::populateFileDataWithFieldSet(FileData& fileData,
+                                                const atlas::FieldSet& fieldSet) {
   oops::Log::debug() << "AtlasWriter::populateMetadataAndDataWithFieldSet()" << std::endl;
   if (mpiCommunicator_.rank() == mpiRankOwner_) {
+    Metadata& metadata = fileData.getMetadata();
+    Data& data = fileData.getData();
     int dimCount = 0;
     bool createdLonLat = false;
     for (const auto& field : fieldSet) {
@@ -258,7 +259,7 @@ void monio::AtlasWriter::populateMetadataAndDataWithFieldSet(Metadata& metadata,
         std::string dimName = metadata.getDimensionName(dimSize);
         if (dimName == consts::kNotFoundError) {
           dimName = "dim" + std::to_string(dimCount);
-          metadata.addDimension(dimName, dimSize);
+          fileData.getMetadata().addDimension(dimName, dimSize);
           dimCount++;
         }
       }
@@ -288,18 +289,18 @@ void monio::AtlasWriter::populateMetadataAndDataWithFieldSet(Metadata& metadata,
 
       std::shared_ptr<monio::AttributeString> producedByAttr =
               std::make_shared<AttributeString>(producedByName, producedByString);
-      metadata.addGlobalAttr(producedByName, producedByAttr);
+      fileData.getMetadata().addGlobalAttr(producedByName, producedByAttr);
     }
   }
 }
 
-void monio::AtlasWriter::populateMetadataAndDataWithLfricFieldSet(
-                                               Metadata& metadata,
-                                               Data& data,
+void monio::AtlasWriter::populateFileDataWithLfricFieldSet(FileData& fileData,
                                          const std::vector<consts::FieldMetadata>& fieldMetadataVec,
                                                atlas::FieldSet& fieldSet,
                                          const std::vector<size_t>& lfricToAtlasMap) {
   oops::Log::debug() << "AtlasWriter::populateMetadataAndDataWithLfricFieldSet()" << std::endl;
+  Metadata& metadata = fileData.getMetadata();
+  Data& data = fileData.getData();
   // Dimensions
   metadata.addDimension(std::string(consts::kHorizontalName), lfricToAtlasMap.size());
   metadata.addDimension(std::string(consts::kVerticalFullName), consts::kVerticalFullSize);
@@ -318,7 +319,7 @@ void monio::AtlasWriter::populateMetadataAndDataWithLfricFieldSet(
 
   std::shared_ptr<monio::AttributeString> producedByAttr =
           std::make_shared<AttributeString>(producedByName, producedByString);
-  metadata.addGlobalAttr(producedByName, producedByAttr);
+  fileData.getMetadata().addGlobalAttr(producedByName, producedByAttr);
 }
 
 void monio::AtlasWriter::populateDataWithField(Data& data,

--- a/src/monio/AtlasWriter.cc
+++ b/src/monio/AtlasWriter.cc
@@ -189,59 +189,6 @@ void monio::AtlasWriter::populateDataContainerWithField(
   }
 }
 
-template<typename T>
-void monio::AtlasWriter::populateDataVec(std::vector<T>& dataVec,
-                                         const atlas::Field& field,
-                                         const std::vector<size_t>& lfricToAtlasMap) {
-  oops::Log::debug() << "AtlasWriter::populateDataVec() " << field.name() << std::endl;
-  atlas::idx_t numLevels = field.levels();
-  if ((lfricToAtlasMap.size() * numLevels) != dataVec.size()) {
-    utils::throwException("AtlasWriter::populateDataVec()> "
-                             "Data container is not configured for the expected data...");
-  }
-  auto fieldView = atlas::array::make_view<T, 2>(field);
-  for (std::size_t i = 0; i < lfricToAtlasMap.size(); ++i) {
-    for (atlas::idx_t j = 0; j < numLevels; ++j) {
-      int index = lfricToAtlasMap[i] + (j * lfricToAtlasMap.size());
-      dataVec[index] = fieldView(i, j);
-    }
-  }
-}
-
-template void monio::AtlasWriter::populateDataVec<double>(std::vector<double>& dataVec,
-                                                    const atlas::Field& field,
-                                                    const std::vector<size_t>& lfricToAtlasMap);
-template void monio::AtlasWriter::populateDataVec<float>(std::vector<float>& dataVec,
-                                                   const atlas::Field& field,
-                                                   const std::vector<size_t>& lfricToAtlasMap);
-template void monio::AtlasWriter::populateDataVec<int>(std::vector<int>& dataVec,
-                                                 const atlas::Field& field,
-                                                 const std::vector<size_t>& lfricToAtlasMap);
-
-template<typename T>
-void monio::AtlasWriter::populateDataVec(std::vector<T>& dataVec,
-                                   const atlas::Field& field,
-                                   const std::vector<int>& dimensions) {
-  oops::Log::debug() << "AtlasWriter::populateDataVec()" << std::endl;
-  auto fieldView = atlas::array::make_view<T, 2>(field);
-  for (atlas::idx_t i = 0; i < dimensions[consts::eHorizontal]; ++i) {  // Horizontal dimension
-    for (atlas::idx_t j = 0; j < dimensions[consts::eVertical]; ++j) {  // Levels dimension
-      int index = j + (i * dimensions[consts::eVertical]);
-      dataVec[index] = fieldView(i, j);
-    }
-  }
-}
-
-template void monio::AtlasWriter::populateDataVec<double>(std::vector<double>& dataVec,
-                                                          const atlas::Field& field,
-                                                          const std::vector<int>& dimensions);
-template void monio::AtlasWriter::populateDataVec<float>(std::vector<float>& dataVec,
-                                                         const atlas::Field& field,
-                                                         const std::vector<int>& dimensions);
-template void monio::AtlasWriter::populateDataVec<int>(std::vector<int>& dataVec,
-                                                       const atlas::Field& field,
-                                                       const std::vector<int>& dimensions);
-
 void monio::AtlasWriter::populateFileDataWithFieldSet(FileData& fileData,
                                                 const atlas::FieldSet& fieldSet) {
   oops::Log::debug() << "AtlasWriter::populateMetadataAndDataWithFieldSet()" << std::endl;
@@ -340,3 +287,56 @@ void monio::AtlasWriter::populateDataWithField(Data& data,
   populateDataContainerWithField(dataContainer, field, dimensions);
   data.addContainer(dataContainer);
 }
+
+template<typename T>
+void monio::AtlasWriter::populateDataVec(std::vector<T>& dataVec,
+                                         const atlas::Field& field,
+                                         const std::vector<size_t>& lfricToAtlasMap) {
+  oops::Log::debug() << "AtlasWriter::populateDataVec() " << field.name() << std::endl;
+  atlas::idx_t numLevels = field.levels();
+  if ((lfricToAtlasMap.size() * numLevels) != dataVec.size()) {
+    utils::throwException("AtlasWriter::populateDataVec()> "
+                             "Data container is not configured for the expected data...");
+  }
+  auto fieldView = atlas::array::make_view<T, 2>(field);
+  for (std::size_t i = 0; i < lfricToAtlasMap.size(); ++i) {
+    for (atlas::idx_t j = 0; j < numLevels; ++j) {
+      int index = lfricToAtlasMap[i] + (j * lfricToAtlasMap.size());
+      dataVec[index] = fieldView(i, j);
+    }
+  }
+}
+
+template void monio::AtlasWriter::populateDataVec<double>(std::vector<double>& dataVec,
+                                                    const atlas::Field& field,
+                                                    const std::vector<size_t>& lfricToAtlasMap);
+template void monio::AtlasWriter::populateDataVec<float>(std::vector<float>& dataVec,
+                                                   const atlas::Field& field,
+                                                   const std::vector<size_t>& lfricToAtlasMap);
+template void monio::AtlasWriter::populateDataVec<int>(std::vector<int>& dataVec,
+                                                 const atlas::Field& field,
+                                                 const std::vector<size_t>& lfricToAtlasMap);
+
+template<typename T>
+void monio::AtlasWriter::populateDataVec(std::vector<T>& dataVec,
+                                   const atlas::Field& field,
+                                   const std::vector<int>& dimensions) {
+  oops::Log::debug() << "AtlasWriter::populateDataVec()" << std::endl;
+  auto fieldView = atlas::array::make_view<T, 2>(field);
+  for (atlas::idx_t i = 0; i < dimensions[consts::eHorizontal]; ++i) {  // Horizontal dimension
+    for (atlas::idx_t j = 0; j < dimensions[consts::eVertical]; ++j) {  // Levels dimension
+      int index = j + (i * dimensions[consts::eVertical]);
+      dataVec[index] = fieldView(i, j);
+    }
+  }
+}
+
+template void monio::AtlasWriter::populateDataVec<double>(std::vector<double>& dataVec,
+                                                          const atlas::Field& field,
+                                                          const std::vector<int>& dimensions);
+template void monio::AtlasWriter::populateDataVec<float>(std::vector<float>& dataVec,
+                                                         const atlas::Field& field,
+                                                         const std::vector<int>& dimensions);
+template void monio::AtlasWriter::populateDataVec<int>(std::vector<int>& dataVec,
+                                                       const atlas::Field& field,
+                                                       const std::vector<int>& dimensions);

--- a/src/monio/AtlasWriter.h
+++ b/src/monio/AtlasWriter.h
@@ -14,8 +14,7 @@
 #include <vector>
 
 #include "Constants.h"
-#include "Data.h"
-#include "Metadata.h"
+#include "FileData.h"
 
 #include "atlas/array/DataType.h"
 #include "atlas/field.h"
@@ -36,15 +35,13 @@ class AtlasWriter {
   AtlasWriter& operator=( AtlasWriter&&)      = delete;  //!< Deleted move assignment
   AtlasWriter& operator=(const AtlasWriter&)  = delete;  //!< Deleted copy assignment
 
-  void populateMetadataAndDataWithFieldSet(Metadata& metadata,
-                                           Data& data,
-                                     const atlas::FieldSet& fieldSet);
+  void populateFileDataWithFieldSet(FileData& fileData,
+                              const atlas::FieldSet& fieldSet);
 
-  void populateMetadataAndDataWithLfricFieldSet(Metadata& metadata,
-                                               Data& data,
-                                         const std::vector<consts::FieldMetadata>& fieldMetadataVec,
-                                               atlas::FieldSet& fieldSet,
-                                         const std::vector<size_t>& lfricToAtlasMap);
+  void populateFileDataWithLfricFieldSet(FileData& fileData,
+                                   const std::vector<consts::FieldMetadata>& fieldMetadataVec,
+                                         atlas::FieldSet& fieldSet,
+                                   const std::vector<size_t>& lfricToAtlasMap);
 
   void populateMetadataWithField(Metadata& metadata,
                            const atlas::Field& field,

--- a/src/monio/AtlasWriter.h
+++ b/src/monio/AtlasWriter.h
@@ -43,6 +43,7 @@ class AtlasWriter {
                                          atlas::FieldSet& fieldSet,
                                    const std::vector<size_t>& lfricToAtlasMap);
 
+ private:
   void populateMetadataWithField(Metadata& metadata,
                            const atlas::Field& field,
                            const consts::FieldMetadata* fieldMetadata = nullptr,
@@ -57,15 +58,6 @@ class AtlasWriter {
                                 const atlas::Field& field,
                                 const std::vector<int>& dimensions);
 
-  template<typename T> void populateDataVec(std::vector<T>& dataVec,
-                                      const atlas::Field& field,
-                                      const std::vector<size_t>& lfricToAtlasMap);
-
-  template<typename T> void populateDataVec(std::vector<T>& dataVec,
-                                      const atlas::Field& field,
-                                      const std::vector<int>& dimensions);
-
- private:
   void populateDataWithField(Data& data,
                        const atlas::Field& field,
                        const std::vector<size_t>& lfricToAtlasMap,
@@ -74,6 +66,14 @@ class AtlasWriter {
   void populateDataWithField(Data& data,
                        const atlas::Field& field,
                        const std::vector<int> dimensions);
+
+  template<typename T> void populateDataVec(std::vector<T>& dataVec,
+                                      const atlas::Field& field,
+                                      const std::vector<size_t>& lfricToAtlasMap);
+
+  template<typename T> void populateDataVec(std::vector<T>& dataVec,
+                                      const atlas::Field& field,
+                                      const std::vector<int>& dimensions);
 
   const eckit::mpi::Comm& mpiCommunicator_;
   const std::size_t mpiRankOwner_;

--- a/src/monio/File.cc
+++ b/src/monio/File.cc
@@ -246,12 +246,10 @@ void monio::File::readAttributes(Metadata& metadata) {
 
 template<typename T>
 void monio::File::readSingleDatum(const std::string& varName,
-                                  const int varSize,
                                   std::vector<T>& dataVec) {
   oops::Log::debug() << "File::readData()" << std::endl;
   if (fileMode_ == netCDF::NcFile::read) {
     auto var = getFile().getVar(varName);
-    dataVec.resize(varSize, 0);
     var.getVar(dataVec.data());
   } else {
     utils::throwException("File::readSingleDatum()> Write file accessed for reading...");
@@ -259,25 +257,20 @@ void monio::File::readSingleDatum(const std::string& varName,
 }
 
 template void monio::File::readSingleDatum<double>(const std::string& varName,
-                                                   const int varSize,
                                                    std::vector<double>& dataVec);
 template void monio::File::readSingleDatum<float>(const std::string& varName,
-                                                  const int varSize,
                                                   std::vector<float>& dataVec);
 template void monio::File::readSingleDatum<int>(const std::string& varName,
-                                                const int varSize,
                                                 std::vector<int>& dataVec);
 
 template<typename T>
 void monio::File::readFieldDatum(const std::string& fieldName,
-                                 const int varSize,
                                  const std::vector<size_t>& startVec,
                                  const std::vector<size_t>& countVec,
                                  std::vector<T>& dataVec) {
   oops::Log::debug() << "File::readFieldDatum()" << std::endl;
   if (fileMode_ == netCDF::NcFile::read) {
     auto var = getFile().getVar(fieldName);
-    dataVec.resize(varSize, 0);
     var.getVar(startVec, countVec, dataVec.data());
   } else {
     utils::throwException("File::readFieldDatum()> Write file accessed for reading...");
@@ -285,17 +278,14 @@ void monio::File::readFieldDatum(const std::string& fieldName,
 }
 
 template void monio::File::readFieldDatum<double>(const std::string& varName,
-                                                  const int varSize,
                                                   const std::vector<size_t>& startVec,
                                                   const std::vector<size_t>& countVec,
                                                   std::vector<double>& dataVec);
 template void monio::File::readFieldDatum<float>(const std::string& varName,
-                                                 const int varSize,
                                                  const std::vector<size_t>& startVec,
                                                  const std::vector<size_t>& countVec,
                                                  std::vector<float>& dataVec);
 template void monio::File::readFieldDatum<int>(const std::string& varName,
-                                               const int varSize,
                                                const std::vector<size_t>& startVec,
                                                const std::vector<size_t>& countVec,
                                                std::vector<int>& dataVec);

--- a/src/monio/File.h
+++ b/src/monio/File.h
@@ -36,11 +36,9 @@ class File {
               const std::vector<std::string>& varNames);
 
   template<typename T> void readSingleDatum(const std::string& varName,
-                                            const int varSize,
                                             std::vector<T>& dataVec);
 
   template<typename T> void readFieldDatum(const std::string& fieldName,
-                                           const int varSize,
                                            const std::vector<size_t>& startVec,
                                            const std::vector<size_t>& countVec,
                                            std::vector<T>& dataVec);

--- a/src/monio/Monio.cc
+++ b/src/monio/Monio.cc
@@ -51,7 +51,7 @@ void monio::Monio::readBackground(atlas::FieldSet& localFieldSet,
       auto& functionSpace = globalField.functionspace();
       auto& grid = atlas::functionspace::NodeColumns(functionSpace).mesh().grid();
 
-      // Initialise background file
+      // Initialise file
       if (fileDataExists(grid.name()) == false) {
         FileData& fileData = createFileData(grid.name(), filePath, dateTime);
         reader_.openFile(fileData);
@@ -100,7 +100,7 @@ void monio::Monio::readIncrements(atlas::FieldSet& localFieldSet,
       auto& functionSpace = globalField.functionspace();
       auto& grid = atlas::functionspace::NodeColumns(functionSpace).mesh().grid();
 
-      // Initialise background file
+      // Initialise file
       if (fileDataExists(grid.name()) == false) {
         FileData& fileData = createFileData(grid.name(), filePath);
         reader_.openFile(fileData);
@@ -162,10 +162,8 @@ void monio::Monio::writeIncrements(const atlas::FieldSet& localFieldSet,
         }
       }
       // Add data and metadata for increments in fieldSet
-      atlasWriter_.populateFileDataWithLfricFieldSet(fileData,
-                                                            fieldMetadataVec,
-                                                            globalFieldSet,
-                                                            lfricAtlasMap);
+      atlasWriter_.populateFileDataWithLfricFieldSet(fileData, fieldMetadataVec,
+                                                     globalFieldSet, lfricAtlasMap);
       monio::Writer writer(atlas::mpi::comm(),
                            consts::kMPIRankOwner,
                            filePath);
@@ -187,8 +185,7 @@ void monio::Monio::writeFieldSet(const atlas::FieldSet& localFieldSet,
       FileData fileData;
       monio::AtlasWriter atlasWriter(atlas::mpi::comm(),
                                      consts::kMPIRankOwner);
-      atlasWriter.populateFileDataWithFieldSet(fileData,
-                                                      globalFieldSet);
+      atlasWriter.populateFileDataWithFieldSet(fileData, globalFieldSet);
       monio::Writer writer(atlas::mpi::comm(), consts::kMPIRankOwner, outputFilePath);
       writer.writeMetadata(fileData.getMetadata());
       writer.writeVariablesData(fileData);

--- a/src/monio/Monio.cc
+++ b/src/monio/Monio.cc
@@ -140,8 +140,6 @@ void monio::Monio::writeIncrements(const atlas::FieldSet& localFieldSet,
     FileData fileData = getFileData(grid.name());
 
     if (filePath.length() != 0) {
-//      monio::Metadata& readMetadata = fileData.getMetadata();
-//      monio::Data& readData = fileData.getData();
       std::vector<size_t>& lfricAtlasMap = fileData.getLfricAtlasMap();
 
       fileData.getMetadata().clearGlobalAttributes();
@@ -164,8 +162,7 @@ void monio::Monio::writeIncrements(const atlas::FieldSet& localFieldSet,
         }
       }
       // Add data and metadata for increments in fieldSet
-      atlasWriter_.populateMetadataAndDataWithLfricFieldSet(fileData.getMetadata(),
-                                                            fileData.getData(),
+      atlasWriter_.populateFileDataWithLfricFieldSet(fileData,
                                                             fieldMetadataVec,
                                                             globalFieldSet,
                                                             lfricAtlasMap);
@@ -190,8 +187,7 @@ void monio::Monio::writeFieldSet(const atlas::FieldSet& localFieldSet,
       FileData fileData;
       monio::AtlasWriter atlasWriter(atlas::mpi::comm(),
                                      consts::kMPIRankOwner);
-      atlasWriter.populateMetadataAndDataWithFieldSet(fileData.getMetadata(),
-                                                      fileData.getData(),
+      atlasWriter.populateFileDataWithFieldSet(fileData,
                                                       globalFieldSet);
       monio::Writer writer(atlas::mpi::comm(), consts::kMPIRankOwner, outputFilePath);
       writer.writeMetadata(fileData.getMetadata());

--- a/src/monio/Monio.cc
+++ b/src/monio/Monio.cc
@@ -140,38 +140,40 @@ void monio::Monio::writeIncrements(const atlas::FieldSet& localFieldSet,
     FileData fileData = getFileData(grid.name());
 
     if (filePath.length() != 0) {
-      monio::Metadata& readMetadata = fileData.getMetadata();
-      monio::Data& readData = fileData.getData();
+//      monio::Metadata& readMetadata = fileData.getMetadata();
+//      monio::Data& readData = fileData.getData();
       std::vector<size_t>& lfricAtlasMap = fileData.getLfricAtlasMap();
 
-      readMetadata.clearGlobalAttributes();
+      fileData.getMetadata().clearGlobalAttributes();
 
-      readMetadata.deleteDimension(std::string(consts::kTimeDimName));
-      readMetadata.deleteDimension(std::string(consts::kTileDimName));
+      fileData.getMetadata().deleteDimension(std::string(consts::kTimeDimName));
+      fileData.getMetadata().deleteDimension(std::string(consts::kTileDimName));
 
-      readData.deleteContainer(std::string(consts::kTimeVarName));
-      readData.deleteContainer(std::string(consts::kTileVarName));
+      fileData.getData().deleteContainer(std::string(consts::kTimeVarName));
+      fileData.getData().deleteContainer(std::string(consts::kTileVarName));
 
       // Reconcile Metadata with Data
       oops::Log::debug() << "AtlasWriter::reconcileMetadataWithData()" << std::endl;
-      std::vector<std::string> metadataVarNames = readMetadata.getVariableNames();
-      std::vector<std::string> dataContainerNames = readData.getDataContainerNames();
+      std::vector<std::string> metadataVarNames = fileData.getMetadata().getVariableNames();
+      std::vector<std::string> dataContainerNames = fileData.getData().getDataContainerNames();
 
       for (const auto& metadataVarName : metadataVarNames) {
         auto it = std::find(begin(dataContainerNames), end(dataContainerNames), metadataVarName);
         if (it == std::end(dataContainerNames)) {
-          readMetadata.deleteVariable(metadataVarName);
+          fileData.getMetadata().deleteVariable(metadataVarName);
         }
       }
       // Add data and metadata for increments in fieldSet
-      atlasWriter_.populateMetadataAndDataWithLfricFieldSet(readMetadata, readData,
-                                                            fieldMetadataVec, globalFieldSet,
+      atlasWriter_.populateMetadataAndDataWithLfricFieldSet(fileData.getMetadata(),
+                                                            fileData.getData(),
+                                                            fieldMetadataVec,
+                                                            globalFieldSet,
                                                             lfricAtlasMap);
       monio::Writer writer(atlas::mpi::comm(),
                            consts::kMPIRankOwner,
                            filePath);
-      writer.writeMetadata(readMetadata);
-      writer.writeVariablesData(readMetadata, readData);
+      writer.writeMetadata(fileData.getMetadata());
+      writer.writeVariablesData(fileData);
     } else {
       oops::Log::info() << "AtlasWriter::writeFieldSetToFile() No outputFilePath supplied. "
                            "NetCDF writing will not take place." << std::endl;
@@ -185,14 +187,15 @@ void monio::Monio::writeFieldSet(const atlas::FieldSet& localFieldSet,
   atlas::FieldSet globalFieldSet = utilsatlas::getGlobalFieldSet(localFieldSet);
   if (atlas::mpi::rank() == consts::kMPIRankOwner) {
     if (outputFilePath.length() != 0) {
-      monio::Metadata metadata;
-      monio::Data data;
+      FileData fileData;
       monio::AtlasWriter atlasWriter(atlas::mpi::comm(),
                                      consts::kMPIRankOwner);
-      atlasWriter.populateMetadataAndDataWithFieldSet(metadata, data, globalFieldSet);
+      atlasWriter.populateMetadataAndDataWithFieldSet(fileData.getMetadata(),
+                                                      fileData.getData(),
+                                                      globalFieldSet);
       monio::Writer writer(atlas::mpi::comm(), consts::kMPIRankOwner, outputFilePath);
-      writer.writeMetadata(metadata);
-      writer.writeVariablesData(metadata, data);
+      writer.writeMetadata(fileData.getMetadata());
+      writer.writeVariablesData(fileData);
     } else {
       oops::Log::info() << "Monio::writeFieldSet() No outputFilePath supplied. "
                            "NetCDF writing will not take place." << std::endl;

--- a/src/monio/Reader.cc
+++ b/src/monio/Reader.cc
@@ -146,24 +146,24 @@ void monio::Reader::readDatumAtTime(FileData& fileData,
         case consts::eDataTypes::eDouble: {
           std::shared_ptr<DataContainerDouble> dataContainerDouble =
                                       std::make_shared<DataContainerDouble>(varName);
-          getFile().readFieldDatum(varName, varSizeNoTime,
-                              startVec, countVec, dataContainerDouble->getData());
+          dataContainerDouble->setSize(varSizeNoTime);
+          getFile().readFieldDatum(varName, startVec, countVec, dataContainerDouble->getData());
           dataContainer = std::static_pointer_cast<DataContainerBase>(dataContainerDouble);
           break;
         }
         case consts::eDataTypes::eFloat: {
           std::shared_ptr<DataContainerFloat> dataContainerFloat =
                                       std::make_shared<DataContainerFloat>(varName);
-          getFile().readFieldDatum(varName, varSizeNoTime,
-                               startVec, countVec, dataContainerFloat->getData());
+          dataContainerFloat->setSize(varSizeNoTime);
+          getFile().readFieldDatum(varName, startVec, countVec, dataContainerFloat->getData());
           dataContainer = std::static_pointer_cast<DataContainerBase>(dataContainerFloat);
           break;
         }
         case consts::eDataTypes::eInt: {
         std::shared_ptr<DataContainerInt> dataContainerInt =
                                       std::make_shared<DataContainerInt>(varName);
-          getFile().readFieldDatum(varName, varSizeNoTime,
-                               startVec, countVec, dataContainerInt->getData());
+          dataContainerInt->setSize(varSizeNoTime);
+          getFile().readFieldDatum(varName, startVec, countVec, dataContainerInt->getData());
           dataContainer = std::static_pointer_cast<DataContainerBase>(dataContainerInt);
           break;
         }
@@ -203,24 +203,24 @@ void monio::Reader::readFullDatum(FileData& fileData,
       case consts::eDataTypes::eDouble: {
         std::shared_ptr<DataContainerDouble> dataContainerDouble =
                             std::make_shared<DataContainerDouble>(varName);
-        getFile().readSingleDatum(varName,
-            variable->getTotalSize(), dataContainerDouble->getData());
+        dataContainerDouble->setSize(variable->getTotalSize());
+        getFile().readSingleDatum(varName, dataContainerDouble->getData());
         dataContainer = std::static_pointer_cast<DataContainerBase>(dataContainerDouble);
         break;
       }
       case consts::eDataTypes::eFloat: {
         std::shared_ptr<DataContainerFloat> dataContainerFloat =
                             std::make_shared<DataContainerFloat>(varName);
-        getFile().readSingleDatum(varName,
-            variable->getTotalSize(), dataContainerFloat->getData());
+        dataContainerFloat->setSize(variable->getTotalSize());
+        getFile().readSingleDatum(varName, dataContainerFloat->getData());
         dataContainer = std::static_pointer_cast<DataContainerBase>(dataContainerFloat);
         break;
       }
       case consts::eDataTypes::eInt: {
         std::shared_ptr<DataContainerInt> dataContainerInt =
                             std::make_shared<DataContainerInt>(varName);
-        getFile().readSingleDatum(varName,
-            variable->getTotalSize(), dataContainerInt->getData());
+        dataContainerInt->setSize(variable->getTotalSize());
+        getFile().readSingleDatum(varName, dataContainerInt->getData());
         dataContainer = std::static_pointer_cast<DataContainerBase>(dataContainerInt);
         break;
       }

--- a/src/monio/Reader.h
+++ b/src/monio/Reader.h
@@ -39,34 +39,23 @@ class Reader {
   Reader& operator=(Reader&&)      = delete;  //!< Deleted move assignment
   Reader& operator=(const Reader&) = delete;  //!< Deleted copy assignment
 
-  void openFile(const FileData& fileData);  // Monio::readBackground
-  void readMetadata(FileData& fileData);    // Monio::readBackground
+  void openFile(const FileData& fileData);
+  void readMetadata(FileData& fileData);
+
+  void readAllData(FileData& fileData);
   void readFullData(FileData& fileData,
-                    const std::vector<std::string>& varNames);  // Monio::readBackground
-  void readFullDatum(FileData& fileData, const std::string& varName);  // Monio::readBackground
+                    const std::vector<std::string>& varNames);
+  void readFullDatum(FileData& fileData, const std::string& varName);
 
   void readDatumAtTime(FileData& fileData,
                       const std::string& variableName,
                       const util::DateTime& dateToRead,
-                      const std::string& timeDimName);  // Monio::readBackground
+                      const std::string& timeDimName);
 
   void readDatumAtTime(FileData& fileData,
                       const std::string& variableName,
                       const size_t timeStep,
-                      const std::string& timeDimName);  // Reader::readDatumAtTime -- private?
-
-  //////////////////////////////////////////////////////////////////////////////////////////////////
-  void readAllData(FileData& fileData);
-
-  void readDataAtTime(FileData& fileData,
-                     const std::vector<std::string>& variableNames,
-                     const std::string& dateString,
-                     const std::string& timeDimName);
-
-  void readDataAtTime(FileData& fileData,
-                     const std::vector<std::string>& variableNames,
-                     const util::DateTime& dateToRead,
-                     const std::string& timeDimName);
+                      const std::string& timeDimName);
 
   std::vector<std::string> getVarStrAttrs(const FileData& fileData,
                                           const std::vector<std::string>& varNames,
@@ -76,8 +65,6 @@ class Reader {
                                                   const std::vector<std::string>& coordNames);
 
  private:
-  size_t getSizeOwned(const FileData& fileData, const std::string& varName);
-  int getVarDataType(const FileData& fileData, const std::string& varName);
   size_t findTimeStep(const FileData& fileData, const util::DateTime& dateTime);
 
   File& getFile();

--- a/src/monio/Reader.h
+++ b/src/monio/Reader.h
@@ -22,8 +22,7 @@
 #include "FileData.h"
 
 namespace monio {
-/// \brief Top-level class uses File, Metadata,
-/// and Data to read from a NetCDF file
+/// \brief Top-level class reads from a NetCDF file and populates FileData
 class Reader {
  public:
   Reader(const eckit::mpi::Comm& mpiCommunicator,

--- a/src/monio/Writer.cc
+++ b/src/monio/Writer.cc
@@ -38,9 +38,9 @@ monio::Writer::Writer(const eckit::mpi::Comm& mpiCommunicator,
   }
 }
 
-void monio::Writer::writeData(const Metadata& metadata, const Data& data) {
-  writeMetadata(metadata);
-  writeVariablesData(metadata, data);
+void monio::Writer::writeData(const FileData& fileData) {
+  writeMetadata(fileData.getMetadata());
+  writeVariablesData(fileData);
 }
 
 void monio::Writer::writeMetadata(const Metadata& metadata) {
@@ -50,38 +50,38 @@ void monio::Writer::writeMetadata(const Metadata& metadata) {
   }
 }
 
-void monio::Writer::writeVariablesData(const Metadata& metadata, const Data& data) {
+void monio::Writer::writeVariablesData(const FileData& fileData) {
   oops::Log::debug() << "Writer::writeVariablesData()" << std::endl;
   if (mpiCommunicator_.rank() == mpiRankOwner_) {
     const std::map<std::string, std::shared_ptr<DataContainerBase>>& dataContainerMap =
-                                                                     data.getContainers();
+                                                                fileData.getData().getContainers();
     for (const auto& dataContainerPair : dataContainerMap) {
       std::string varName = dataContainerPair.first;
       // Checks variable exists in metadata
-      metadata.getVariable(varName);
+      fileData.getMetadata().getVariable(varName);
       std::shared_ptr<DataContainerBase> dataContainer = dataContainerPair.second;
       int dataType = dataContainerPair.second->getType();
       switch (dataType) {
-      case consts::eDataTypes::eDouble: {
-        std::shared_ptr<DataContainerDouble> dataContainerDouble =
-            std::static_pointer_cast<DataContainerDouble>(dataContainer);
-        getFile().writeSingleDatum(varName, dataContainerDouble->getData());
-        break;
-      }
-      case consts::eDataTypes::eFloat: {
-        std::shared_ptr<DataContainerFloat> dataContainerFloat =
-            std::static_pointer_cast<DataContainerFloat>(dataContainer);
-        getFile().writeSingleDatum(varName, dataContainerFloat->getData());
-        break;
-      }
-      case consts::eDataTypes::eInt: {
-        std::shared_ptr<DataContainerInt> dataContainerInt =
-            std::static_pointer_cast<DataContainerInt>(dataContainer);
-        getFile().writeSingleDatum(varName, dataContainerInt->getData());
-        break;
-      }
-      default:
-        utils::throwException("Writer::writeVariablesData()> Data type not coded for...");
+        case consts::eDataTypes::eDouble: {
+          std::shared_ptr<DataContainerDouble> dataContainerDouble =
+              std::static_pointer_cast<DataContainerDouble>(dataContainer);
+          getFile().writeSingleDatum(varName, dataContainerDouble->getData());
+          break;
+        }
+        case consts::eDataTypes::eFloat: {
+          std::shared_ptr<DataContainerFloat> dataContainerFloat =
+              std::static_pointer_cast<DataContainerFloat>(dataContainer);
+          getFile().writeSingleDatum(varName, dataContainerFloat->getData());
+          break;
+        }
+        case consts::eDataTypes::eInt: {
+          std::shared_ptr<DataContainerInt> dataContainerInt =
+              std::static_pointer_cast<DataContainerInt>(dataContainer);
+          getFile().writeSingleDatum(varName, dataContainerInt->getData());
+          break;
+        }
+        default:
+          utils::throwException("Writer::writeVariablesData()> Data type not coded for...");
       }
     }
   }

--- a/src/monio/Writer.h
+++ b/src/monio/Writer.h
@@ -22,8 +22,7 @@
 #include "Metadata.h"
 
 namespace monio {
-/// \brief Top-level class uses File, Metadata, AtlasData,
-/// and Data to write to a NetCDF file
+/// \brief Top-level class uses FileData and its contents to write to a NetCDF file
 class Writer {
  public:
   explicit Writer(const eckit::mpi::Comm& mpiCommunicator,

--- a/src/monio/Writer.h
+++ b/src/monio/Writer.h
@@ -18,6 +18,7 @@
 
 #include "Data.h"
 #include "File.h"
+#include "FileData.h"
 #include "Metadata.h"
 
 namespace monio {
@@ -35,9 +36,9 @@ class Writer {
   Writer& operator=(Writer&&)      = delete;  //!< Deleted move assign
   Writer& operator=(const Writer&) = delete;  //!< Deleted copy assign
 
-  void writeData(const Metadata& metadata, const Data& data);
+  void writeData(const FileData& fileData);
   void writeMetadata(const Metadata& metadata);
-  void writeVariablesData(const Metadata& metadata, const Data& data);
+  void writeVariablesData(const FileData& fileData);
 
  private:
   File& getFile();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -47,13 +47,13 @@ ecbuild_add_test(TARGET monio_coding_norms
                        ${PROJECT_SOURCE_DIR}/src
                        ${PROJECT_SOURCE_DIR}/test)
 
-ecbuild_add_test(TARGET  test_state_basic
+ecbuild_add_test(TARGET  test_monio_state_basic
                  SOURCES mains/TestStateBasic.cc
                  ARGS    "testinput/state_basic.yaml"
                  LIBS    monio
                  MPI     4)
 
-ecbuild_add_test(TARGET  test_state_full
+ecbuild_add_test(TARGET  test_monio_state_full
                  SOURCES mains/TestStateFull.cc
                  ARGS    "testinput/state_full.yaml"
                  LIBS    monio

--- a/test/monio/StateBasic.h
+++ b/test/monio/StateBasic.h
@@ -57,7 +57,7 @@ void testFunction() {
     monio::Writer writer(atlas::mpi::comm(),
                          monio::consts::kMPIRankOwner,
                          outputFilePath);
-    writer.writeData(firstFileData.getMetadata(), firstFileData.getData());
+    writer.writeData(firstFileData);
 
     monio::FileData secondFileData(outputFilePath);
     reader.openFile(secondFileData);


### PR DESCRIPTION
A number of small changes. The biggest of which was converting to the use of the FileData container class, over Data/Metadata in applicable functions in AtlasWriter. Also changed the accessibility of some functions and removed unused ones.

Current test outputs: http://fcm1/cylc-review/taskjobs/punderwo/?suite=monio_reader_and_writer2