### PR TITLE
Bugfix/fieldset write

### DIFF
--- a/src/monio/AtlasWriter.cc
+++ b/src/monio/AtlasWriter.cc
@@ -46,7 +46,6 @@ void monio::AtlasWriter::populateFileDataWithField(FileData& fileData,
     Metadata& metadata = fileData.getMetadata();
     Data& data = fileData.getData();
     // Create dims
-    int dimCount = 0;
     std::vector<int> dimVec = field.shape();
     if (field.metadata().get<bool>("global") == false) {
       dimVec[0] = utilsatlas::getSizeOwned(field);
@@ -54,9 +53,9 @@ void monio::AtlasWriter::populateFileDataWithField(FileData& fileData,
     for (auto& dimSize : dimVec) {
       std::string dimName = metadata.getDimensionName(dimSize);
       if (dimName == consts::kNotFoundError) {
-        dimName = "dim" + std::to_string(dimCount);
+        dimName = "dim" + std::to_string(dimCount_);
         fileData.getMetadata().addDimension(dimName, dimSize);
-        dimCount++;
+        dimCount_++;
       }
     }
     populateMetadataWithField(metadata, field);

--- a/src/monio/AtlasWriter.h
+++ b/src/monio/AtlasWriter.h
@@ -71,5 +71,7 @@ class AtlasWriter {
 
   const eckit::mpi::Comm& mpiCommunicator_;
   const std::size_t mpiRankOwner_;
+
+  int dimCount_ = 0;  // Used for automatic creation of dimension names
 };
 }  // namespace monio

--- a/src/monio/Monio.cc
+++ b/src/monio/Monio.cc
@@ -265,11 +265,11 @@ void monio::Monio::writeFieldSet(const atlas::FieldSet& localFieldSet,
   }
   if (filePath.length() != 0) {
     try {
+      FileData fileData;
       writer_.openFile(filePath);
       for (const auto& localField : localFieldSet) {
         atlas::Field globalField = utilsatlas::getGlobalField(localField);
         if (mpiCommunicator_.rank() == mpiRankOwner_) {
-          FileData fileData;
           std::shared_ptr<monio::DataContainerBase> dataContainer = nullptr;
           atlasWriter_.populateFileDataWithField(fileData, globalField);
           writer_.writeMetadata(fileData.getMetadata());

--- a/src/monio/Monio.cc
+++ b/src/monio/Monio.cc
@@ -235,12 +235,11 @@ void monio::Monio::writeIncrements(const atlas::FieldSet& localFieldSet,
         FileData fileData = getFileData(grid.name());
         cleanFileData(fileData);
         if (mpiCommunicator_.rank() == mpiRankOwner_) {
-          //std::vector<size_t>& lfricAtlasMap = fileData.getLfricAtlasMap();
-          //atlasWriter_.populateFileDataWithLfricFieldSet(fileData, fieldMetadataVec,
+          // std::vector<size_t>& lfricAtlasMap = fileData.getLfricAtlasMap();
+          // atlasWriter_.populateFileDataWithLfricFieldSet(fileData, fieldMetadataVec,
           //                                               globalFieldSet, lfricAtlasMap);
           writer_.writeMetadata(fileData.getMetadata());
           writer_.writeData(fileData);
-
         }
       }
       writer_.closeFile();

--- a/src/monio/Monio.cc
+++ b/src/monio/Monio.cc
@@ -225,42 +225,34 @@ void monio::Monio::writeIncrements(const atlas::FieldSet& localFieldSet,
     utils::throwException("Monio::writeIncrements()> localFieldSet has zero fields...");
   }
   if (filePath.length() != 0) {
-    atlas::FieldSet globalFieldSet = utilsatlas::getGlobalFieldSet(localFieldSet);
-    if (mpiCommunicator_.rank() == mpiRankOwner_) {
-      auto& functionSpace = globalFieldSet[0].functionspace();
-      auto& grid = atlas::functionspace::NodeColumns(functionSpace).mesh().grid();
+    try {
+      writer_.openFile(filePath);
+      for (const auto& localField : localFieldSet) {
+        atlas::Field globalField = utilsatlas::getGlobalField(localField);
+        auto& functionSpace = globalField.functionspace();
+        auto& grid = atlas::functionspace::NodeColumns(functionSpace).mesh().grid();
 
-      FileData fileData = getFileData(grid.name());
-      std::vector<size_t>& lfricAtlasMap = fileData.getLfricAtlasMap();
+        FileData fileData = getFileData(grid.name());
+        cleanFileData(fileData);
+        if (mpiCommunicator_.rank() == mpiRankOwner_) {
+          //std::vector<size_t>& lfricAtlasMap = fileData.getLfricAtlasMap();
+          //atlasWriter_.populateFileDataWithLfricFieldSet(fileData, fieldMetadataVec,
+          //                                               globalFieldSet, lfricAtlasMap);
+          writer_.writeMetadata(fileData.getMetadata());
+          writer_.writeData(fileData);
 
-      fileData.getMetadata().clearGlobalAttributes();
-      fileData.getMetadata().deleteDimension(std::string(consts::kTimeDimName));
-      fileData.getMetadata().deleteDimension(std::string(consts::kTileDimName));
-
-      fileData.getData().deleteContainer(std::string(consts::kTimeVarName));
-      fileData.getData().deleteContainer(std::string(consts::kTileVarName));
-
-      // Reconcile Metadata with Data
-      std::vector<std::string> metadataVarNames = fileData.getMetadata().getVariableNames();
-      std::vector<std::string> dataContainerNames = fileData.getData().getDataContainerNames();
-
-      for (const auto& metadataVarName : metadataVarNames) {
-        auto it = std::find(begin(dataContainerNames), end(dataContainerNames), metadataVarName);
-        if (it == std::end(dataContainerNames)) {
-          fileData.getMetadata().deleteVariable(metadataVarName);
         }
       }
-      // Add data and metadata for increments in fieldSet
-      // atlasWriter_.populateFileDataWithLfricFieldSet(fileData, fieldMetadataVec,
-      //                                                globalFieldSet, lfricAtlasMap);
-      writer_.openFile(filePath);
-      writer_.writeMetadata(fileData.getMetadata());
-      writer_.writeData(fileData);
       writer_.closeFile();
-    } else {
+    } catch (netCDF::exceptions::NcException& exception) {
+      writer_.closeFile();
+      std::string exceptionMessage = exception.what();
+      utils::throwException("Monio::writeFieldSet()> An exception occurred: " +
+                              exceptionMessage);
+    }
+  } else {
       oops::Log::info() << "Monio::writeIncrements()> No file path supplied. "
                            "NetCDF writing will not take place..." << std::endl;
-    }
   }
 }
 
@@ -273,11 +265,11 @@ void monio::Monio::writeFieldSet(const atlas::FieldSet& localFieldSet,
   }
   if (filePath.length() != 0) {
     try {
-      FileData fileData;
       writer_.openFile(filePath);
       for (const auto& localField : localFieldSet) {
         atlas::Field globalField = utilsatlas::getGlobalField(localField);
         if (mpiCommunicator_.rank() == mpiRankOwner_) {
+          FileData fileData;
           std::shared_ptr<monio::DataContainerBase> dataContainer = nullptr;
           atlasWriter_.populateFileDataWithField(fileData, globalField);
           writer_.writeMetadata(fileData.getMetadata());
@@ -400,6 +392,27 @@ bool monio::Monio::fileDataExists(const std::string& gridName) const {
     return true;
   }
   return false;
+}
+
+void monio::Monio::cleanFileData(FileData& fileData) {
+  fileData.getMetadata().clearGlobalAttributes();
+  fileData.getMetadata().deleteDimension(std::string(consts::kTimeDimName));
+  fileData.getMetadata().deleteDimension(std::string(consts::kTileDimName));
+
+  fileData.getData().deleteContainer(std::string(consts::kTimeVarName));
+  fileData.getData().deleteContainer(std::string(consts::kTileVarName));
+
+  // Reconcile Metadata with Data
+  std::vector<std::string> metadataVarNames = fileData.getMetadata().getVariableNames();
+  std::vector<std::string> dataContainerNames = fileData.getData().getDataContainerNames();
+
+  for (const auto& metadataVarName : metadataVarNames) {
+    auto it = std::find(begin(dataContainerNames),
+                        end(dataContainerNames), metadataVarName);
+    if (it == std::end(dataContainerNames)) {
+      fileData.getMetadata().deleteVariable(metadataVarName);
+    }
+  }
 }
 
 monio::Monio::Monio(const eckit::mpi::Comm& mpiCommunicator,

--- a/src/monio/Monio.cc
+++ b/src/monio/Monio.cc
@@ -265,7 +265,7 @@ void monio::Monio::writeFieldSet(const atlas::FieldSet& localFieldSet,
   }
   if (filePath.length() != 0) {
     try {
-      FileData fileData;
+      FileData fileData;  // Object needs to persist across fields for correct metadata creation
       writer_.openFile(filePath);
       for (const auto& localField : localFieldSet) {
         atlas::Field globalField = utilsatlas::getGlobalField(localField);
@@ -274,7 +274,7 @@ void monio::Monio::writeFieldSet(const atlas::FieldSet& localFieldSet,
           atlasWriter_.populateFileDataWithField(fileData, globalField);
           writer_.writeMetadata(fileData.getMetadata());
           writer_.writeData(fileData);
-          fileData.clearData();
+          fileData.clearData();  // Globalised field data no longer required
         }
       }
       writer_.closeFile();

--- a/src/monio/Monio.h
+++ b/src/monio/Monio.h
@@ -71,10 +71,11 @@ class Monio {
                        const std::string& timeVarName,
                        const std::string& timeOriginName);
 
-  // This function returns copies of FileData by design
-  FileData getFileData(const std::string& gridName);
+  FileData getFileData(const std::string& gridName);  // This function returns copies by design
 
   bool fileDataExists(const std::string& gridName) const;
+
+  void cleanFileData(FileData& fileData);
 
   static Monio* this_;
 


### PR DESCRIPTION
Fix of problem with `Monio::writeFieldSet` which didn't preserve dimensions across fields during memory-efficient write. It accidentally arrived at something that would have probably worked, but would likely have caused problems when used generally.

Current test outputs: http://fcm1/cylc-review/taskjobs/punderwo/?suite=monio_fieldset_write1

See below for plots of data:
![pot_temp](https://github.com/MetOffice/monio/assets/48318251/6cf133b0-5396-4a2f-8215-8401da05174b)
![skin_temp](https://github.com/MetOffice/monio/assets/48318251/4e21a789-c6e3-498d-88df-fcf46cac9d2b)

NB: Please ignore changes to `Monio:writeIncrements`. It was easier to include the changes here than it was to backtrack and isolate the changes for this bugfix.