### PR TITLE
Feature/increment write

### DIFF
--- a/src/monio/AtlasReader.cc
+++ b/src/monio/AtlasReader.cc
@@ -14,7 +14,7 @@
 #include "UtilsAtlas.h"
 
 monio::AtlasReader::AtlasReader(const eckit::mpi::Comm& mpiCommunicator,
-                                    const atlas::idx_t mpiRankOwner):
+                                    const int mpiRankOwner):
     mpiCommunicator_(mpiCommunicator),
     mpiRankOwner_(mpiRankOwner) {
   oops::Log::debug() << "AtlasReader::AtlasReader()" << std::endl;
@@ -91,11 +91,11 @@ void monio::AtlasReader::populateField(atlas::Field& field,
                                        const bool copyFirstLevel) {
   oops::Log::debug() << "AtlasReader::populateField()" << std::endl;
   auto fieldView = atlas::array::make_view<T, 2>(field);
-  atlas::idx_t numLevels = field.levels();
+  int numLevels = field.levels();
   if (copyFirstLevel == true) {
     numLevels -= 1;
   }
-  for (atlas::idx_t j = 0; j < numLevels; ++j) {
+  for (int j = 0; j < numLevels; ++j) {
     for (std::size_t i = 0; i < lfricToAtlasMap.size(); ++i) {
       int index = lfricToAtlasMap[i] + (j * lfricToAtlasMap.size());
       if (std::size_t(index) <= dataVec.size()) {
@@ -126,14 +126,14 @@ void monio::AtlasReader::populateField(atlas::Field& field,
                                        const std::vector<T>& dataVec) {
   oops::Log::debug() << "AtlasReader::populateField()" << std::endl;
 
-  std::vector<atlas::idx_t> dimVec = field.shape();
+  std::vector<int> dimVec = field.shape();
   if (field.metadata().get<bool>("global") == false) {
-    dimVec[consts::eHorizontal] = utilsatlas::getSizeOwned(field);
+    dimVec[consts::eHorizontal] = utilsatlas::getHorizontalSize(field);
   }
   auto fieldView = atlas::array::make_view<T, 2>(field);
-  atlas::idx_t numLevels = field.levels();
-  for (atlas::idx_t i = 0; i < dimVec[consts::eHorizontal]; ++i) {
-    for (atlas::idx_t j = 0; j < numLevels; ++j) {
+  int numLevels = field.levels();
+  for (int i = 0; i < dimVec[consts::eHorizontal]; ++i) {
+    for (int j = 0; j < numLevels; ++j) {
       int index = i + (j * dimVec[consts::eHorizontal]);
       if (std::size_t(index) <= dataVec.size()) {
         fieldView(i, j) = dataVec[index];

--- a/src/monio/AtlasReader.h
+++ b/src/monio/AtlasReader.h
@@ -32,7 +32,7 @@ namespace monio {
 class AtlasReader {
  public:
   AtlasReader(const eckit::mpi::Comm& mpiCommunicator,
-              const atlas::idx_t mpiRankOwner);
+              const int mpiRankOwner);
 
   AtlasReader()                               = delete;  //!< Deleted default constructor
   AtlasReader(AtlasReader&&)                  = delete;  //!< Deleted move constructor

--- a/src/monio/AtlasWriter.cc
+++ b/src/monio/AtlasWriter.cc
@@ -338,9 +338,11 @@ void monio::AtlasWriter::addGlobalAttributes(Metadata& metadata, const bool isLf
                                                    std::string(consts::kDataFormatAtlas);
   // Create attribute objects
   std::shared_ptr<monio::AttributeString> producedByAttr =
-      std::make_shared<AttributeString>(std::string(consts::kProducedByName), std::string(consts::kProducedByString));
+      std::make_shared<AttributeString>(std::string(consts::kProducedByName),
+                                        std::string(consts::kProducedByString));
   std::shared_ptr<monio::AttributeString> formatAttr =
-      std::make_shared<AttributeString>(std::string(consts::kDataFormatName), formatType);
+      std::make_shared<AttributeString>(std::string(consts::kDataFormatName),
+                                        formatType);
   // Add to metadata
   metadata.addGlobalAttr(formatAttr->getName(), formatAttr);
   metadata.addGlobalAttr(producedByAttr->getName(), producedByAttr);

--- a/src/monio/AtlasWriter.h
+++ b/src/monio/AtlasWriter.h
@@ -27,7 +27,7 @@ namespace monio {
 class AtlasWriter {
  public:
   AtlasWriter(const eckit::mpi::Comm& mpiCommunicator,
-              const atlas::idx_t mpiRankOwner);
+              const int mpiRankOwner);
 
   AtlasWriter()                               = delete;  //!< Deleted default constructor
   AtlasWriter(AtlasWriter&&)                  = delete;  //!< Deleted move constructor

--- a/src/monio/AtlasWriter.h
+++ b/src/monio/AtlasWriter.h
@@ -36,17 +36,19 @@ class AtlasWriter {
   AtlasWriter& operator=(const AtlasWriter&)  = delete;  //!< Deleted copy assignment
 
   void populateFileDataWithField(FileData& fileData,
-                           const atlas::Field& field);
+                           const atlas::Field& field,
+                           const std::string& writeName);
 
   void populateFileDataWithField(FileData& fileData,
                                  atlas::Field& field,
-                           const std::string& writeName,
-                           const bool copyFirstLevel = false);
+                           const consts::FieldMetadata& fieldMetadata,
+                           const std::string& writeName);
 
  private:
   void populateDataContainerWithField(std::shared_ptr<monio::DataContainerBase>& dataContainer,
                                 const atlas::Field& field,
-                                const std::vector<size_t>& lfricToAtlasMap);
+                                const std::vector<size_t>& lfricToAtlasMap,
+                                const std::string& fieldName);
 
   void populateDataContainerWithField(std::shared_ptr<monio::DataContainerBase>& dataContainer,
                                 const atlas::Field& field,
@@ -54,11 +56,18 @@ class AtlasWriter {
 
 
   void populateMetadataWithField(Metadata& metadata,
-                           const atlas::Field& field);
+                           const atlas::Field& field,
+                           const consts::FieldMetadata& fieldMetadata,
+                           const std::string& varName);
+
+  void populateMetadataWithField(Metadata& metadata,
+                           const atlas::Field& field,
+                           const std::string& varName);
 
   void populateDataWithField(Data& data,
                        const atlas::Field& field,
-                       const std::vector<size_t>& lfricToAtlasMap);
+                       const std::vector<size_t>& lfricToAtlasMap,
+                       const std::string& fieldName);
 
   void populateDataWithField(Data& data,
                        const atlas::Field& field,

--- a/src/monio/AtlasWriter.h
+++ b/src/monio/AtlasWriter.h
@@ -38,11 +38,15 @@ class AtlasWriter {
   void populateFileDataWithField(FileData& fileData,
                            const atlas::Field& field);
 
+  void populateFileDataWithField(FileData& fileData,
+                                 atlas::Field& field,
+                           const std::string& writeName,
+                           const bool copyFirstLevel = false);
+
  private:
   void populateDataContainerWithField(std::shared_ptr<monio::DataContainerBase>& dataContainer,
                                 const atlas::Field& field,
-                                const std::vector<size_t>& lfricToAtlasMap,
-                                const size_t fieldSize);
+                                const std::vector<size_t>& lfricToAtlasMap);
 
   void populateDataContainerWithField(std::shared_ptr<monio::DataContainerBase>& dataContainer,
                                 const atlas::Field& field,
@@ -54,8 +58,7 @@ class AtlasWriter {
 
   void populateDataWithField(Data& data,
                        const atlas::Field& field,
-                       const std::vector<size_t>& lfricToAtlasMap,
-                       const size_t totalFieldSize);
+                       const std::vector<size_t>& lfricToAtlasMap);
 
   void populateDataWithField(Data& data,
                        const atlas::Field& field,

--- a/src/monio/AtlasWriter.h
+++ b/src/monio/AtlasWriter.h
@@ -35,14 +35,17 @@ class AtlasWriter {
   AtlasWriter& operator=( AtlasWriter&&)      = delete;  //!< Deleted move assignment
   AtlasWriter& operator=(const AtlasWriter&)  = delete;  //!< Deleted copy assignment
 
+  // For writing of FieldSets with no metadata
   void populateFileDataWithField(FileData& fileData,
                            const atlas::Field& field,
                            const std::string& writeName);
 
+  // For writing LFRic data with some existing metadata
   void populateFileDataWithField(FileData& fileData,
                                  atlas::Field& field,
                            const consts::FieldMetadata& fieldMetadata,
-                           const std::string& writeName);
+                           const std::string& writeName,
+                           const bool isLfricFormat);
 
  private:
   void populateDataContainerWithField(std::shared_ptr<monio::DataContainerBase>& dataContainer,
@@ -80,6 +83,11 @@ class AtlasWriter {
   template<typename T> void populateDataVec(std::vector<T>& dataVec,
                                       const atlas::Field& field,
                                       const std::vector<int>& dimensions);
+
+  void addVariableDimensions(const atlas::Field& field,
+                             const Metadata& metadata,
+                             std::shared_ptr<monio::Variable> var);
+  void addGlobalAttributes(Metadata& metadata, const bool isLFRicFormat = true);
 
   const eckit::mpi::Comm& mpiCommunicator_;
   const std::size_t mpiRankOwner_;

--- a/src/monio/Constants.h
+++ b/src/monio/Constants.h
@@ -143,6 +143,9 @@ const std::string_view kTabSpace = "    ";
 const std::string_view kLevelsSearchTerm = "levels";
 const std::string_view kNotFoundError = "NOT_FOUND";
 
+const std::string_view kToBeDerived = "TO BE DERIVED";
+const std::string_view kToBeImplemented = "TO BE IMPLEMENTED";
+
 //////////////////////////////////////////////////////////////////////////////////////////////////
 /// Increment file metadata attributes
 /// Attribute names

--- a/src/monio/Constants.h
+++ b/src/monio/Constants.h
@@ -186,7 +186,7 @@ const std::string_view  kIncrementVariableValues[eNumberOfAttributeNames] {
 };
 //////////////////////////////////////////////////////////////////////////////////////////////////
 
-const atlas::idx_t kMPIRankOwner = 0;
+const int kMPIRankOwner = 0;
 
 const int kVerticalFullSize = 71;
 const int kVerticalHalfSize = 70;

--- a/src/monio/Constants.h
+++ b/src/monio/Constants.h
@@ -146,6 +146,13 @@ const std::string_view kNotFoundError = "NOT_FOUND";
 const std::string_view kToBeDerived = "TO BE DERIVED";
 const std::string_view kToBeImplemented = "TO BE IMPLEMENTED";
 
+const std::string_view kProducedByName = "Produced_by";
+const std::string_view kProducedByString = "MONIO: Met Office NetCDF I/O";
+
+const std::string_view kDataFormatName = "Data_format";
+const std::string_view kDataFormatAtlas = "Atlas";
+const std::string_view kDataFormatLfric = "LFRic";
+
 //////////////////////////////////////////////////////////////////////////////////////////////////
 /// Increment file metadata attributes
 /// Attribute names

--- a/src/monio/Data.cc
+++ b/src/monio/Data.cc
@@ -112,9 +112,7 @@ void monio::Data::deleteContainer(const std::string& name) {
   auto it = dataContainers_.find(name);
   if (it != dataContainers_.end()) {
     dataContainers_.erase(name);
-  } else {
-    utils::throwException("DataContainer named \"" + name + "\" was not found.");
-  }
+  }  // Non-existant container is a legitimate use-case.
 }
 
 void monio::Data::removeAllButTheseContainers(const std::vector<std::string>& varNames) {

--- a/src/monio/Metadata.cc
+++ b/src/monio/Metadata.cc
@@ -342,10 +342,7 @@ void monio::Metadata::deleteDimension(const std::string& dimName) {
   auto itDim = dimensions_.find(dimName);
   if (itDim != dimensions_.end()) {
     dimensions_.erase(dimName);
-  } else {
-    utils::throwException("Metadata::deleteDimension()> Dimension \"" +
-                               dimName + "\" not found...");
-  }
+  }  // Non-existant dimension is a legitimate use-case.
   for (const auto& varPair : variables_) {
     varPair.second->deleteDimension(dimName);
   }

--- a/src/monio/Metadata.cc
+++ b/src/monio/Metadata.cc
@@ -156,6 +156,15 @@ std::string monio::Metadata::getDimensionName(const int dimValue) {
   return std::string(consts::kNotFoundError);
 }
 
+const std::string monio::Metadata::getDimensionName(const int dimValue) const {
+  for (auto it = dimensions_.begin(); it != dimensions_.end(); ++it) {
+    if (it->second == dimValue) {
+      return it->first;
+    }
+  }
+  return std::string(consts::kNotFoundError);
+}
+
 std::shared_ptr<monio::Variable> monio::Metadata::getVariable(const std::string& varName) {
   oops::Log::debug() << "Metadata::getVariable()> " << varName << std::endl;
   auto it = variables_.find(varName);

--- a/src/monio/Metadata.h
+++ b/src/monio/Metadata.h
@@ -29,6 +29,7 @@ class Metadata {
   int getDimension(const std::string& dimName);
 
   std::string getDimensionName(const int dimValue);
+  const std::string getDimensionName(const int dimValue) const;
 
   std::shared_ptr<Variable> getVariable(const std::string& varName);
   const std::shared_ptr<Variable> getVariable(const std::string& varName) const;

--- a/src/monio/Monio.cc
+++ b/src/monio/Monio.cc
@@ -241,10 +241,13 @@ void monio::Monio::writeIncrements(const atlas::FieldSet& localFieldSet,
         auto& localField = localFieldSet[fieldMetadata.jediName];
         atlas::Field globalField = utilsatlas::getGlobalField(localField);
         if (mpiCommunicator_.rank() == mpiRankOwner_) {
+
+          std::string writeName = isLfricFormat == true ? fieldMetadata.lfricWriteName :
+                                                          globalField.name();
           atlasWriter_.populateFileDataWithField(fileData,
                                                  globalField,
-                                                 fieldMetadata.lfricWriteName,
-                                                 fieldMetadata.copyFirstLevel);
+                                                 fieldMetadata,
+                                                 writeName);
           writer_.writeMetadata(fileData.getMetadata());
           writer_.writeData(fileData);
           fileData.clearData();  // Globalised field data no longer required
@@ -276,7 +279,7 @@ void monio::Monio::writeFieldSet(const atlas::FieldSet& localFieldSet,
       for (const auto& localField : localFieldSet) {
         atlas::Field globalField = utilsatlas::getGlobalField(localField);
         if (mpiCommunicator_.rank() == mpiRankOwner_) {
-          atlasWriter_.populateFileDataWithField(fileData, globalField);
+          atlasWriter_.populateFileDataWithField(fileData, globalField, globalField.name());
           writer_.writeMetadata(fileData.getMetadata());
           writer_.writeData(fileData);
           fileData.clearData();  // Globalised field data no longer required

--- a/src/monio/Monio.cc
+++ b/src/monio/Monio.cc
@@ -241,7 +241,6 @@ void monio::Monio::writeIncrements(const atlas::FieldSet& localFieldSet,
         auto& localField = localFieldSet[fieldMetadata.jediName];
         atlas::Field globalField = utilsatlas::getGlobalField(localField);
         if (mpiCommunicator_.rank() == mpiRankOwner_) {
-
           std::string writeName = isLfricFormat == true ? fieldMetadata.lfricWriteName :
                                                           globalField.name();
           atlasWriter_.populateFileDataWithField(fileData,

--- a/src/monio/Monio.cc
+++ b/src/monio/Monio.cc
@@ -246,7 +246,8 @@ void monio::Monio::writeIncrements(const atlas::FieldSet& localFieldSet,
           atlasWriter_.populateFileDataWithField(fileData,
                                                  globalField,
                                                  fieldMetadata,
-                                                 writeName);
+                                                 writeName,
+                                                 isLfricFormat);
           writer_.writeMetadata(fileData.getMetadata());
           writer_.writeData(fileData);
           fileData.clearData();  // Globalised field data no longer required

--- a/src/monio/Monio.cc
+++ b/src/monio/Monio.cc
@@ -400,11 +400,10 @@ bool monio::Monio::fileDataExists(const std::string& gridName) const {
 
 void monio::Monio::cleanFileData(FileData& fileData) {
   fileData.getMetadata().clearGlobalAttributes();
-  // PJU FIX
-  // fileData.getMetadata().deleteDimension(std::string(consts::kTimeDimName));
-  // fileData.getMetadata().deleteDimension(std::string(consts::kTileDimName));
-  // fileData.getData().deleteContainer(std::string(consts::kTimeVarName));
-  // fileData.getData().deleteContainer(std::string(consts::kTileVarName));
+  fileData.getMetadata().deleteDimension(std::string(consts::kTimeDimName));
+  fileData.getMetadata().deleteDimension(std::string(consts::kTileDimName));
+  fileData.getData().deleteContainer(std::string(consts::kTimeVarName));
+  fileData.getData().deleteContainer(std::string(consts::kTileVarName));
 
   // Reconcile Metadata with Data
   std::vector<std::string> metadataVarNames = fileData.getMetadata().getVariableNames();

--- a/src/monio/Monio.cc
+++ b/src/monio/Monio.cc
@@ -226,13 +226,6 @@ void monio::Monio::writeIncrements(const atlas::FieldSet& localFieldSet,
   }
   if (filePath.length() != 0) {
     try {
-      for (const auto& fieldMetadata : fieldMetadataVec) {
-        auto& localField = localFieldSet[fieldMetadata.jediName];
-        atlas::Field globalField = utilsatlas::getGlobalField(localField);
-
-      }
-
-
       auto& functionSpace = localFieldSet[0].functionspace();
       auto& grid = atlas::functionspace::NodeColumns(functionSpace).mesh().grid();
       FileData fileData = getFileData(grid.name());

--- a/src/monio/Monio.h
+++ b/src/monio/Monio.h
@@ -33,6 +33,10 @@ class Monio {
   Monio& operator=(Monio&&)      = delete;  //!< Deleted move assignment
   Monio& operator=(const Monio&) = delete;  //!< Deleted copy assignment
 
+  void initialiseFile(const atlas::Grid& grid,
+                      const std::string& filePath,
+                      const util::DateTime& dateTime);  // Public, only whilst this method is called directly from LFRic-Lite
+
   void readState(atlas::FieldSet& localFieldSet,
                 const std::vector<consts::FieldMetadata>& fieldMetadataVec,
                 const std::string& filePath,
@@ -56,7 +60,7 @@ class Monio {
 
  private:
   Monio(const eckit::mpi::Comm& mpiCommunicator,
-        const atlas::idx_t mpiRankOwner);
+        const int mpiRankOwner);
 
   FileData& createFileData(const std::string& gridName,
                            const std::string& filePath,

--- a/src/monio/Monio.h
+++ b/src/monio/Monio.h
@@ -33,9 +33,10 @@ class Monio {
   Monio& operator=(Monio&&)      = delete;  //!< Deleted move assignment
   Monio& operator=(const Monio&) = delete;  //!< Deleted copy assignment
 
+
   void initialiseFile(const atlas::Grid& grid,
                       const std::string& filePath,
-                      const util::DateTime& dateTime);  // Public, only whilst this method is called directly from LFRic-Lite
+                      const util::DateTime& dateTime);  // Public, whilst called from LFRic-Lite
 
   void readState(atlas::FieldSet& localFieldSet,
                 const std::vector<consts::FieldMetadata>& fieldMetadataVec,

--- a/src/monio/Reader.cc
+++ b/src/monio/Reader.cc
@@ -25,7 +25,7 @@
 #include "oops/util/Logger.h"
 
 monio::Reader::Reader(const eckit::mpi::Comm& mpiCommunicator,
-                      const atlas::idx_t mpiRankOwner,
+                      const int mpiRankOwner,
                       const std::string& filePath):
     mpiCommunicator_(mpiCommunicator),
     mpiRankOwner_(mpiRankOwner) {
@@ -34,7 +34,7 @@ monio::Reader::Reader(const eckit::mpi::Comm& mpiCommunicator,
 }
 
 monio::Reader::Reader(const eckit::mpi::Comm& mpiCommunicator,
-                      const atlas::idx_t mpiRankOwner):
+                      const int mpiRankOwner):
     mpiCommunicator_(mpiCommunicator),
     mpiRankOwner_(mpiRankOwner) {
   oops::Log::debug() << "Reader::Reader()" << std::endl;

--- a/src/monio/Reader.h
+++ b/src/monio/Reader.h
@@ -26,11 +26,11 @@ namespace monio {
 class Reader {
  public:
   explicit Reader(const eckit::mpi::Comm& mpiCommunicator,
-                  const atlas::idx_t mpiRankOwner,
+                  const int mpiRankOwner,
                   const std::string& filePath);
 
   explicit Reader(const eckit::mpi::Comm& mpiCommunicator,
-                  const atlas::idx_t mpiRankOwner);
+                  const int mpiRankOwner);
 
   Reader()                         = delete;  //!< Deleted default constructor
   Reader(Reader&&)                 = delete;  //!< Deleted move constructor

--- a/src/monio/UtilsAtlas.cc
+++ b/src/monio/UtilsAtlas.cc
@@ -60,7 +60,7 @@ std::vector<atlas::PointLonLat> getAtlasCoords(const atlas::Field& field) {
   if (field.metadata().get<bool>("global") == false) {
     auto lonLatField = field.functionspace().lonlat();
     auto lonLatView = atlas::array::make_view<double, 2>(lonLatField);
-    for (int i = 0; i < getSizeOwned(field); ++i) {
+    for (int i = 0; i < getHorizontalSize(field); ++i) {
       atlasCoords.push_back(atlas::PointLonLat(lonLatView(i, consts::eLongitude),
                                                lonLatView(i, consts::eLatitude)));
     }
@@ -200,18 +200,28 @@ atlas::FieldSet getGlobalFieldSet(const atlas::FieldSet& fieldSet) {
 }
 
 
-atlas::idx_t getSizeOwned(const atlas::Field& field) {
+int getHorizontalSize(const atlas::Field& field) {
   atlas::Field ghostField = field.functionspace().ghost();
-  atlas::idx_t sizeOwned = 0;
+  int size = 0;
   auto ghostView = atlas::array::make_view<int, 1>(ghostField);
-  for (atlas::idx_t i = ghostField.size() - 1; i >= 0; --i) {
+  for (int i = ghostField.size() - 1; i >= 0; --i) {
     if (ghostView(i) == 0) {
-      sizeOwned = i + 1;
+      size = i + 1;
       break;
     }
   }
-  return sizeOwned;
+  return size;
 }
+
+int getDataSize(const atlas::Field& field) {
+  std::vector<int> dimVec = field.shape();
+  int size = 1;
+  for (const auto& dim : dimVec) {
+    size *= dim;
+  }
+  return size;
+}
+
 
 template<typename T>
 atlas::Field copySurfaceLevel(const atlas::Field& inputField,
@@ -222,8 +232,8 @@ atlas::Field copySurfaceLevel(const atlas::Field& inputField,
   auto copiedFieldView = atlas::array::make_view<T, 2>(copiedField);
   auto inputFieldView = atlas::array::make_view<T, 2>(inputField);
   std::vector<int> dimVec = inputField.shape();
-  for (atlas::idx_t j = 0; j < dimVec[consts::eVertical]; ++j) {
-    for (atlas::idx_t i = 0; i < dimVec[consts::eHorizontal]; ++i) {
+  for (int j = 0; j < dimVec[consts::eVertical]; ++j) {
+    for (int i = 0; i < dimVec[consts::eHorizontal]; ++i) {
       copiedFieldView(i, j + 1) = inputFieldView(i, j);
     }
   }

--- a/src/monio/UtilsAtlas.cc
+++ b/src/monio/UtilsAtlas.cc
@@ -199,7 +199,6 @@ atlas::FieldSet getGlobalFieldSet(const atlas::FieldSet& fieldSet) {
   }
 }
 
-
 int getHorizontalSize(const atlas::Field& field) {
   atlas::Field ghostField = field.functionspace().ghost();
   int size = 0;

--- a/src/monio/UtilsAtlas.cc
+++ b/src/monio/UtilsAtlas.cc
@@ -157,16 +157,16 @@ atlas::Field getGlobalField(const atlas::Field& field) {
 }
 
 atlas::Field getFormattedField(atlas::Field& inputField,
-                               const consts::FieldMetadata& fieldMetadata) {
+                         const std::string& writeName,
+                         const bool copyFirstLevel) {
   oops::Log::debug() << "AtlasWriter::processField()" << std::endl;
   atlas::FunctionSpace functionSpace = inputField.functionspace();
   atlas::array::DataType atlasType = inputField.datatype();
 
   // WARNING - This name-check is an LFRic-Lite specific convention...
-  if (fieldMetadata.lfricWriteName != "TO BE DERIVED" &&
-      fieldMetadata.lfricWriteName != "TO BE IMPLEMENTED") {
-    if (fieldMetadata.copyFirstLevel == true) {
-      atlas::util::Config atlasOptions = atlas::option::name(fieldMetadata.lfricWriteName) |
+  if (writeName != consts::kToBeDerived && writeName != consts::kToBeImplemented) {
+    if (copyFirstLevel == true) {
+      atlas::util::Config atlasOptions = atlas::option::name(writeName) |
                                          atlas::option::global(0) |
                                          atlas::option::levels(inputField.levels() + 1);
       switch (atlasType.kind()) {
@@ -181,7 +181,7 @@ atlas::Field getFormattedField(atlas::Field& inputField,
         }
       }
     } else {
-      inputField.metadata().set("name", fieldMetadata.lfricWriteName);
+      inputField.metadata().set("name", writeName);
     }
   }
   return inputField;

--- a/src/monio/UtilsAtlas.h
+++ b/src/monio/UtilsAtlas.h
@@ -42,7 +42,8 @@ namespace utilsatlas {
 
   atlas::Field getGlobalField(const atlas::Field& field);
   atlas::Field getFormattedField(atlas::Field& inputField,
-                                 const consts::FieldMetadata& fieldMetadata);
+                           const std::string& writeName,
+                           const bool copyFirstLevel);
 
   template<typename T>
   atlas::Field copySurfaceLevel(const atlas::Field& inputField,

--- a/src/monio/UtilsAtlas.h
+++ b/src/monio/UtilsAtlas.h
@@ -50,7 +50,8 @@ namespace utilsatlas {
                                 const atlas::FunctionSpace& functionSpace,
                                 const atlas::util::Config& atlasOptions);
 
-  atlas::idx_t getSizeOwned(const atlas::Field& field);
+  int getHorizontalSize(const atlas::Field& field);  // Just 2D size
+  int getDataSize(const atlas::Field& field);  // Full 3D size of data
 
   int atlasTypeToMonioEnum(atlas::array::DataType atlasType);
 }  // namespace utilsatlas

--- a/src/monio/Writer.cc
+++ b/src/monio/Writer.cc
@@ -21,7 +21,7 @@
 #include "oops/util/Logger.h"
 
 monio::Writer::Writer(const eckit::mpi::Comm& mpiCommunicator,
-                      const atlas::idx_t mpiRankOwner,
+                      const int mpiRankOwner,
                       const std::string& filePath) :
     mpiCommunicator_(mpiCommunicator),
     mpiRankOwner_(mpiRankOwner) {
@@ -30,7 +30,7 @@ monio::Writer::Writer(const eckit::mpi::Comm& mpiCommunicator,
 }
 
 monio::Writer::Writer(const eckit::mpi::Comm& mpiCommunicator,
-                      const atlas::idx_t mpiRankOwner) :
+                      const int mpiRankOwner) :
     mpiCommunicator_(mpiCommunicator),
     mpiRankOwner_(mpiRankOwner) {
   oops::Log::debug() << "Writer::Writer()" << std::endl;

--- a/src/monio/Writer.h
+++ b/src/monio/Writer.h
@@ -26,11 +26,11 @@ namespace monio {
 class Writer {
  public:
   explicit Writer(const eckit::mpi::Comm& mpiCommunicator,
-                  const atlas::idx_t mpiRankOwner,
+                  const int mpiRankOwner,
                   const std::string& filePath);
 
   explicit Writer(const eckit::mpi::Comm& mpiCommunicator,
-                  const atlas::idx_t mpiRankOwner);
+                  const int mpiRankOwner);
 
   Writer()                         = delete;  //!< Deleted default constructor
   Writer(Writer&&)                 = delete;  //!< Deleted move constructor


### PR DESCRIPTION
This PR introduces the necessary changes to MONIO for use of `Monio::writeIncrements` from LFRic-Lite.

Current test outputs: http://fcm1/cylc-review/taskjobs/punderwo/?suite=monio_increment_write_05

The work in MONIO for use of `Monio::readIncrements` will come next, but the work in LFRic-Lite to use both of these functions will appear in a single PR.