### PR TITLE
Feature/state read

### DIFF
--- a/src/monio/AtlasWriter.cc
+++ b/src/monio/AtlasWriter.cc
@@ -319,7 +319,11 @@ atlas::Field monio::AtlasWriter::getWriteField(atlas::Field& field,
   oops::Log::debug() << "AtlasWriter::getWriteField()" << std::endl;
   atlas::FunctionSpace functionSpace = field.functionspace();
   atlas::array::DataType atlasType = field.datatype();
-
+  if (atlasType != atlasType.KIND_REAL64 &&
+      atlasType != atlasType.KIND_REAL32 &&
+      atlasType != atlasType.KIND_INT32) {
+      utils::throwException("AtlasWriter::getWriteField())> Data type not coded for...");
+  }
   // Erroneous case. For noFirstLevel == true field should have 70 levels
   if (noFirstLevel == true && field.levels() == consts::kVerticalFullSize) {
     utils::throwException("AtlasWriter::getWriteField()> Field levels misconfiguration...");

--- a/src/monio/Monio.cc
+++ b/src/monio/Monio.cc
@@ -96,8 +96,6 @@ void monio::Monio::readState(atlas::FieldSet& localFieldSet,
           auto& localField = localFieldSet[fieldMetadata.jediName];
           atlas::Field globalField = utilsatlas::getGlobalField(localField);
           if (mpiCommunicator_.rank() == mpiRankOwner_) {
-            oops::Log::debug() << "Monio::readState() processing data for> \"" <<
-                                  fieldMetadata.jediName << "\"..." << std::endl;
             auto& functionSpace = globalField.functionspace();
             auto& grid = atlas::functionspace::NodeColumns(functionSpace).mesh().grid();
 
@@ -110,9 +108,9 @@ void monio::Monio::readState(atlas::FieldSet& localFieldSet,
             std::string readName = fieldMetadata.lfricReadName;
             if (namingConvention == consts::eJediNaming) {
               readName = fieldMetadata.jediName;
-            } else {
-              readName = fieldMetadata.lfricReadName;  // Default to LFRic naming convention
             }
+            oops::Log::debug() << "Monio::readState() processing data for> \"" <<
+                                  readName << "\"..." << std::endl;
             // Read fields into memory
             reader_.readDatumAtTime(fileData, readName, dateTime,
                                     std::string(consts::kTimeDimName));
@@ -150,8 +148,6 @@ void monio::Monio::readIncrements(atlas::FieldSet& localFieldSet,
           auto& localField = localFieldSet[fieldMetadata.jediName];
           atlas::Field globalField = utilsatlas::getGlobalField(localField);
           if (mpiCommunicator_.rank() == mpiRankOwner_) {
-            oops::Log::debug() << "Monio::readIncrements() processing data for> \"" <<
-                                  fieldMetadata.jediName << "\"..." << std::endl;
             auto& functionSpace = globalField.functionspace();
             auto& grid = atlas::functionspace::NodeColumns(functionSpace).mesh().grid();
 
@@ -161,18 +157,12 @@ void monio::Monio::readIncrements(atlas::FieldSet& localFieldSet,
             // is discarded when FileData goes out-of-scope for reading subsequent fields.
             FileData fileData = getFileData(grid.name());
             // Configure read name
-            std::string readName;
-            switch (namingConvention) {
-              case consts::eLfricNaming:
-                readName = fieldMetadata.lfricReadName;
-                break;
-              case consts::eJediNaming:
-                readName = fieldMetadata.jediName;
-                break;
-              default:
-                utils::throwException("Monio::readIncrements()> "
-                                      "File naming convention not defined...");
+            std::string readName = fieldMetadata.lfricReadName;
+            if (namingConvention == consts::eJediNaming) {
+              readName = fieldMetadata.jediName;
             }
+            oops::Log::debug() << "Monio::readIncrements() processing data for> \"" <<
+                                  readName << "\"..." << std::endl;
             // Read fields into memory
             reader_.readFullDatum(fileData, readName);
             atlasReader_.populateFieldWithFileData(globalField, fileData, fieldMetadata, readName);


### PR DESCRIPTION
A few tweaks and alterations as part of the use of `Monio::stateRead` from LFRic-JEDI. Fixed an issue where input file was closed and not reopened when accessed multiple times. Changed the derivation of the "naming convention" from input files (for increment and state read). Not all files contain this metadata field, in which case the assumption is that the data adopt LFRic naming. Added additional error checking in AtlasWriter (as suggested by @mo-joshuacolclough).

Current test outputs: http://fcm1/cylc-review/taskjobs/punderwo/?suite=monio_state_read_01