### PR TITLE
Full test and file closures on exception

### DIFF
--- a/src/monio/AtlasReader.cc
+++ b/src/monio/AtlasReader.cc
@@ -10,6 +10,7 @@
 
 #include "oops/util/Logger.h"
 
+#include "Monio.h"
 #include "Utils.h"
 #include "UtilsAtlas.h"
 
@@ -58,9 +59,11 @@ void monio::AtlasReader::populateFieldWithDataContainer(atlas::Field& field,
           populateField(field, dataContainerInt->getData(), lfricToAtlasMap, noFirstLevel);
       break;
     }
-    default:
-      utils::throwException("AtlasReader::populateFieldWithDataContainer()> "
-                               "Data type not coded for...");
+    default: {
+        Monio::get().closeFiles();
+        utils::throwException("AtlasReader::populateFieldWithDataContainer()> "
+                                 "Data type not coded for...");
+      }
     }
   }
 }
@@ -89,9 +92,11 @@ void monio::AtlasReader::populateFieldWithDataContainer(atlas::Field& field,
           populateField(field, dataContainerInt->getData());
       break;
     }
-    default:
-      utils::throwException("AtlasReader::populateFieldWithDataContainer()> "
-                               "Data type not coded for...");
+    default: {
+        Monio::get().closeFiles();
+        utils::throwException("AtlasReader::populateFieldWithDataContainer()> "
+                                 "Data type not coded for...");
+      }
     }
   }
 }
@@ -105,6 +110,7 @@ void monio::AtlasReader::populateField(atlas::Field& field,
   auto fieldView = atlas::array::make_view<T, 2>(field);
   // Field with noFirstLevel == true should have been adjusted to have 70 levels.
   if (noFirstLevel == true && field.levels() == consts::kVerticalFullSize) {
+    Monio::get().closeFiles();
     utils::throwException("AtlasReader::populateField()> Field levels misconfiguration...");
   // Only valid case for field with noFirstLevel == true. Field is adjusted to have 70 levels but
   // read data still has enough to fill 71.
@@ -116,6 +122,7 @@ void monio::AtlasReader::populateField(atlas::Field& field,
         if (std::size_t(index) <= dataVec.size()) {
           fieldView(i, j - 1) = dataVec[index];
         } else {
+          Monio::get().closeFiles();
           utils::throwException("AtlasReader::populateField()> Calculated index exceeds size of "
                                 "data for field \"" + field.name() + "\".");
         }
@@ -130,6 +137,7 @@ void monio::AtlasReader::populateField(atlas::Field& field,
         if (std::size_t(index) <= dataVec.size()) {
           fieldView(i, j) = dataVec[index];
         } else {
+          Monio::get().closeFiles();
           utils::throwException("AtlasReader::populateField()> Calculated index exceeds size of "
                                 "data for field \"" + field.name() + "\".");
         }
@@ -168,6 +176,7 @@ void monio::AtlasReader::populateField(atlas::Field& field,
       if (std::size_t(index) <= dataVec.size()) {
         fieldView(i, j) = dataVec[index];
       } else {
+        Monio::get().closeFiles();
         utils::throwException("AtlasReader::populateField()> "
                               "Calculated index exceeds size of data.");
       }
@@ -190,6 +199,7 @@ atlas::Field monio::AtlasReader::getReadField(atlas::Field& field,
     if (atlasType != atlasType.KIND_REAL64 &&
         atlasType != atlasType.KIND_REAL32 &&
         atlasType != atlasType.KIND_INT32) {
+        Monio::get().closeFiles();
         utils::throwException("AtlasReader::getReadField())> Data type not coded for...");
     }
     atlas::util::Config atlasOptions = atlas::option::name(field.name()) |

--- a/src/monio/AtlasWriter.cc
+++ b/src/monio/AtlasWriter.cc
@@ -17,6 +17,7 @@
 #include "DataContainerFloat.h"
 #include "DataContainerInt.h"
 #include "Metadata.h"
+#include "Monio.h"
 #include "Utils.h"
 #include "UtilsAtlas.h"
 #include "Writer.h"
@@ -183,6 +184,7 @@ void monio::AtlasWriter::populateDataContainerWithField(
         break;
       }
       default: {
+        Monio::get().closeFiles();
         utils::throwException("AtlasWriter::populateDataContainerWithField()> "
                                  "Data type not coded for...");
       }
@@ -234,9 +236,11 @@ void monio::AtlasWriter::populateDataContainerWithField(
       populateDataVec(dataContainerDouble->getData(), field, dimensions);
       break;
     }
-    default:
-      utils::throwException("AtlasWriter::populateDataContainerWithField()> "
-                               "Data type not coded for...");
+    default: {
+        Monio::get().closeFiles();
+        utils::throwException("AtlasWriter::populateDataContainerWithField()> "
+                                 "Data type not coded for...");
+      }
     }
   }
 }
@@ -267,6 +271,7 @@ void monio::AtlasWriter::populateDataVec(std::vector<T>& dataVec,
   oops::Log::debug() << "AtlasWriter::populateDataVec() " << field.name() << std::endl;
   int numLevels = field.levels();
   if ((lfricToAtlasMap.size() * numLevels) != dataVec.size()) {
+    Monio::get().closeFiles();
     utils::throwException("AtlasWriter::populateDataVec()> "
                           "Data container is not configured for the expected data...");
   }
@@ -322,10 +327,12 @@ atlas::Field monio::AtlasWriter::getWriteField(atlas::Field& field,
   if (atlasType != atlasType.KIND_REAL64 &&
       atlasType != atlasType.KIND_REAL32 &&
       atlasType != atlasType.KIND_INT32) {
+      Monio::get().closeFiles();
       utils::throwException("AtlasWriter::getWriteField())> Data type not coded for...");
   }
   // Erroneous case. For noFirstLevel == true field should have 70 levels
   if (noFirstLevel == true && field.levels() == consts::kVerticalFullSize) {
+    Monio::get().closeFiles();
     utils::throwException("AtlasWriter::getWriteField()> Field levels misconfiguration...");
   }
   // WARNING - This name-check is an LFRic-Lite specific convention...
@@ -349,6 +356,7 @@ atlas::Field monio::AtlasWriter::getWriteField(atlas::Field& field,
       field.metadata().set("name", writeName);
     }
   } else {
+    Monio::get().closeFiles();
     utils::throwException("AtlasWriter::getWriteField()> Field write name misconfiguration...");
   }
   return field;

--- a/src/monio/Data.cc
+++ b/src/monio/Data.cc
@@ -17,6 +17,7 @@
 #include "DataContainerDouble.h"
 #include "DataContainerFloat.h"
 #include "DataContainerInt.h"
+#include "Monio.h"
 #include "Utils.h"
 
 namespace {
@@ -142,6 +143,7 @@ std::shared_ptr<monio::DataContainerBase>
   if (it != dataContainers_.end()) {
     return it->second;
   } else {
+    Monio::get().closeFiles();
     utils::throwException("DataContainer named \"" + name + "\" was not found.");
   }
 }

--- a/src/monio/DataContainerDouble.cc
+++ b/src/monio/DataContainerDouble.cc
@@ -11,6 +11,7 @@
 #include <stdexcept>
 
 #include "Constants.h"
+#include "Monio.h"
 #include "Utils.h"
 
 monio::DataContainerDouble::DataContainerDouble(const std::string& name) :
@@ -33,9 +34,10 @@ const double* monio::DataContainerDouble::getDataPointer() {
 }
 
 const double& monio::DataContainerDouble::getDatum(const size_t index) {
-  if (index > dataVector_.size())
-    utils::throwException("DataContainerDouble::getDatum()> "
-        "Passed index exceeds vector size...");
+  if (index > dataVector_.size()) {
+    Monio::get().closeFiles();
+    utils::throwException("DataContainerDouble::getDatum()> Passed index exceeds vector size...");
+  }
 
   return dataVector_[index];
 }

--- a/src/monio/DataContainerFloat.cc
+++ b/src/monio/DataContainerFloat.cc
@@ -11,6 +11,7 @@
 #include <stdexcept>
 
 #include "Constants.h"
+#include "Monio.h"
 #include "Utils.h"
 
 monio::DataContainerFloat::DataContainerFloat(const std::string& name) :
@@ -33,9 +34,10 @@ const float* monio::DataContainerFloat::getDataPointer() {
 }
 
 const float& monio::DataContainerFloat::getDatum(const size_t index) {
-  if (index > dataVector_.size())
-    utils::throwException("DataContainerFloat::getDatum()> "
-        "Passed index exceeds vector size...");
+  if (index > dataVector_.size()) {
+    Monio::get().closeFiles();
+    utils::throwException("DataContainerFloat::getDatum()> Passed index exceeds vector size...");
+  }
 
   return dataVector_[index];
 }

--- a/src/monio/DataContainerInt.cc
+++ b/src/monio/DataContainerInt.cc
@@ -11,6 +11,7 @@
 #include <stdexcept>
 
 #include "Constants.h"
+#include "Monio.h"
 #include "Utils.h"
 
 monio::DataContainerInt::DataContainerInt(const std::string& name) :
@@ -33,10 +34,10 @@ const int* monio::DataContainerInt::getDataPointer() {
 }
 
 const int& monio::DataContainerInt::getDatum(const size_t index) {
-  if (index > dataVector_.size())
-    utils::throwException("DataContainerInt::getDatum()> "
-        "Passed index exceeds vector size...");
-
+  if (index > dataVector_.size()) {
+    Monio::get().closeFiles();
+    utils::throwException("DataContainerInt::getDatum()> Passed index exceeds vector size...");
+  }
   return dataVector_[index];
 }
 

--- a/src/monio/Metadata.cc
+++ b/src/monio/Metadata.cc
@@ -20,6 +20,7 @@
 #include "AttributeDouble.h"
 #include "AttributeInt.h"
 #include "AttributeString.h"
+#include "Monio.h"
 #include "Utils.h"
 
 monio::Metadata::Metadata() {
@@ -142,8 +143,8 @@ int monio::Metadata::getDimension(const std::string& dimName) {
   if (isDimDefined(dimName) == true) {
     return dimensions_.at(dimName);
   } else {
-    utils::throwException("Metadata::getDimension()> dimension \"" +
-                                dimName + "\" not found...");
+    Monio::get().closeFiles();
+    utils::throwException("Metadata::getDimension()> dimension \"" + dimName + "\" not found...");
   }
 }
 
@@ -171,8 +172,8 @@ std::shared_ptr<monio::Variable> monio::Metadata::getVariable(const std::string&
   if (it != variables_.end()) {
     return variables_.at(varName);
   } else {
-    utils::throwException("Metadata::getVariable()> variable \"" +
-                                varName + "\" not found...");
+    Monio::get().closeFiles();
+    utils::throwException("Metadata::getVariable()> variable \"" + varName + "\" not found...");
   }
 }
 
@@ -184,8 +185,8 @@ const std::shared_ptr<monio::Variable>
   if (it != variables_.end()) {
     return variables_.at(varName);
   } else {
-    utils::throwException("Metadata::getVariable()> variable \"" +
-                                varName + "\" not found...");
+    Monio::get().closeFiles();
+    utils::throwException("Metadata::getVariable()> variable \"" + varName + "\" not found...");
   }
 }
 
@@ -226,6 +227,7 @@ const std::vector<std::string> monio::Metadata::getVarStrAttrs(
       varStrAttrs.push_back(attr);
   }
   if (varNames.size() != varStrAttrs.size()) {
+    Monio::get().closeFiles();
     utils::throwException("Metadata::getVarStrAttrs()> "
         "Unmatched number of variables and attributes...");
   }
@@ -364,8 +366,8 @@ void monio::Metadata::deleteVariable(const std::string& varName) {
   if (it != variables_.end()) {
     variables_.erase(varName);
   } else {
-    utils::throwException("Metadata::deleteVariable()> Variable \"" +
-                             varName + "\" not found...");
+    Monio::get().closeFiles();
+    utils::throwException("Metadata::deleteVariable()> Variable \"" + varName + "\" not found...");
   }
 }
 
@@ -435,9 +437,10 @@ void monio::Metadata::printVariables() {
           oops::Log::debug() << std::quoted(netCDFAttrStr->getValue()) << std::endl;
           break;
         }
-        default:
-          utils::throwException("Metadata::printGlobalAttrs()> "
-                                   "Data type not coded for...");
+        default: {
+          Monio::get().closeFiles();
+          utils::throwException("Metadata::printGlobalAttrs()> Data type not coded for...");
+        }
       }
     }
   }
@@ -467,8 +470,10 @@ void monio::Metadata::printGlobalAttrs() {
         oops::Log::debug() << " = " << std::quoted(globAttrStr->getValue()) << " ;"  << std::endl;
         break;
       }
-      default:
+      default: {
+        Monio::get().closeFiles();
         utils::throwException("Metadata::printGlobalAttrs()> Data type not coded for...");
+      }
     }
   }
 }

--- a/src/monio/Monio.cc
+++ b/src/monio/Monio.cc
@@ -46,6 +46,7 @@ int monio::Monio::initialiseFile(const atlas::Grid& grid,
     // Read data
     std::vector<std::string> meshVars =
         fileData.getMetadata().findVariableNames(std::string(consts::kLfricMeshTerm));
+    reader_.openFile(filePath);
     reader_.readFullData(fileData, meshVars);
     reader_.readFullDatum(fileData, std::string(consts::kVerticalFullName));
     reader_.readFullDatum(fileData, std::string(consts::kVerticalHalfName));
@@ -297,7 +298,6 @@ void monio::Monio::writeIncrements(const atlas::FieldSet& localFieldSet,
 void monio::Monio::writeFieldSet(const atlas::FieldSet& localFieldSet,
                                  const std::string& filePath) {
   oops::Log::debug() << "Monio::writeFieldSet()" << std::endl;
-
   if (localFieldSet.size() == 0) {
     utils::throwException("Monio::writeFieldSet()> localFieldSet has zero fields...");
   }
@@ -324,6 +324,12 @@ void monio::Monio::writeFieldSet(const atlas::FieldSet& localFieldSet,
     oops::Log::info() << "Monio::writeFieldSet()> No file path supplied. "
                          "NetCDF writing will not take place..." << std::endl;
   }
+}
+
+void monio::Monio::closeFiles() {
+  oops::Log::debug() << "Monio::closeFiles()" << std::endl;
+  reader_.closeFile();
+  writer_.closeFile();
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/monio/Monio.cc
+++ b/src/monio/Monio.cc
@@ -189,57 +189,50 @@ void monio::Monio::readIncrements(atlas::FieldSet& localFieldSet,
 
 void monio::Monio::writeState(const atlas::FieldSet& localFieldSet,
                               const std::vector<consts::FieldMetadata>& fieldMetadataVec,
-                              const std::string& filePath) {
+                              const std::string& filePath,
+                              const bool isLfricNaming) {
   oops::Log::debug() << "Monio::writeState()" << std::endl;
   if (localFieldSet.size() == 0) {
     utils::throwException("Monio::writeState()> localFieldSet has zero fields...");
   }
   if (filePath.length() != 0) {
     try {
+      auto& functionSpace = localFieldSet[0].functionspace();
+      auto& grid = atlas::functionspace::NodeColumns(functionSpace).mesh().grid();
+      FileData fileData = getFileData(grid.name());
+      cleanFileData(fileData);
+      writer_.openFile(filePath);
       for (const auto& fieldMetadata : fieldMetadataVec) {
         auto& localField = localFieldSet[fieldMetadata.jediName];
         atlas::Field globalField = utilsatlas::getGlobalField(localField);
         if (mpiCommunicator_.rank() == mpiRankOwner_) {
-          oops::Log::debug() << "Monio::writeState() processing data for> \"" <<
-                                fieldMetadata.jediName << "\"..." << std::endl;
-          auto& functionSpace = globalField.functionspace();
-          auto& grid = atlas::functionspace::NodeColumns(functionSpace).mesh().grid();
-
-          FileData fileData = getFileData(grid.name());
-          std::vector<size_t>& lfricAtlasMap = fileData.getLfricAtlasMap();
-
-          fileData.getMetadata().clearGlobalAttributes();
-          fileData.getMetadata().deleteDimension(std::string(consts::kTimeDimName));
-          fileData.getMetadata().deleteDimension(std::string(consts::kTileDimName));
-
-          fileData.getData().deleteContainer(std::string(consts::kTimeVarName));
-          fileData.getData().deleteContainer(std::string(consts::kTileVarName));
-
-          // Reconcile Metadata with Data
-          std::vector<std::string> metadataVarNames = fileData.getMetadata().getVariableNames();
-          std::vector<std::string> dataContainerNames = fileData.getData().getDataContainerNames();
-
-          for (const auto& metadataVarName : metadataVarNames) {
-            auto it = std::find(begin(dataContainerNames),
-                                end(dataContainerNames), metadataVarName);
-            if (it == std::end(dataContainerNames)) {
-              fileData.getMetadata().deleteVariable(metadataVarName);
-            }
+          // Configure write name
+          std::string writeName;
+          if (isLfricNaming == true) {
+            writeName = fieldMetadata.lfricWriteName;
+          } else if (isLfricNaming == false && fieldMetadata.jediName == globalField.name()) {
+            writeName = fieldMetadata.jediName;
+          } else {
+            utils::throwException("Monio::writeState()> Field metadata configuration error...");
           }
+          oops::Log::debug() << "Monio::writeState() processing data for> \"" <<
+                                  writeName << "\"..." << std::endl;
 
-          // Add data and metadata for increments in fieldSet
-          // atlasWriter_.populateFileDataWithLfricFieldSet(fileData, fieldMetadataVec,
-          //                                                globalFieldSet, lfricAtlasMap);
-          writer_.openFile(filePath);
+          atlasWriter_.populateFileDataWithField(fileData,
+                                                 globalField,
+                                                 fieldMetadata,
+                                                 writeName,
+                                                 isLfricNaming);
           writer_.writeMetadata(fileData.getMetadata());
           writer_.writeData(fileData);
+          fileData.clearData();  // Globalised field data no longer required
         }
       }
+      writer_.closeFile();
     } catch (netCDF::exceptions::NcException& exception) {
       writer_.closeFile();
       std::string exceptionMessage = exception.what();
-      utils::throwException("Monio::writeState()> An exception has occurred: " +
-                            exceptionMessage);
+      utils::throwException("Monio::writeState()> An exception has occurred: " + exceptionMessage);
     }
   } else {
     oops::Log::info() << "Monio::writeState()> No file path supplied. "
@@ -276,6 +269,9 @@ void monio::Monio::writeIncrements(const atlas::FieldSet& localFieldSet,
             utils::throwException("Monio::writeIncrements()> "
                                   "Field metadata configuration error...");
           }
+          oops::Log::debug() << "Monio::writeIncrements() processing data for> \"" <<
+                                writeName << "\"..." << std::endl;
+
           atlasWriter_.populateFileDataWithField(fileData,
                                                  globalField,
                                                  fieldMetadata,

--- a/src/monio/Monio.cc
+++ b/src/monio/Monio.cc
@@ -210,7 +210,7 @@ void monio::Monio::writeState(const atlas::FieldSet& localFieldSet,
           // Configure write name
           std::string writeName;
           if (isLfricNaming == true) {
-            writeName = fieldMetadata.lfricWriteName;
+            writeName = fieldMetadata.lfricReadName;
           } else if (isLfricNaming == false && fieldMetadata.jediName == globalField.name()) {
             writeName = fieldMetadata.jediName;
           } else {

--- a/src/monio/Monio.h
+++ b/src/monio/Monio.h
@@ -49,7 +49,8 @@ class Monio {
 
   void writeState(const atlas::FieldSet& localFieldSet,
                   const std::vector<consts::FieldMetadata>& fieldMetadataVec,
-                  const std::string& filePath);
+                  const std::string& filePath,
+                  const bool isLfricNaming = true);
 
   void writeIncrements(const atlas::FieldSet& localFieldSet,
                        const std::vector<consts::FieldMetadata>& fieldMetadataVec,

--- a/src/monio/Monio.h
+++ b/src/monio/Monio.h
@@ -46,15 +46,15 @@ class Monio {
                 const std::vector<consts::FieldMetadata>& fieldMetadataVec,
                 const std::string& filePath);
 
-  void writeState(const atlas::FieldSet& localFieldSet,
-                  const std::vector<consts::FieldMetadata>& fieldMetadataVec,
-                  const std::string& filePath,
-                  const bool isLfricNaming = true);
-
   void writeIncrements(const atlas::FieldSet& localFieldSet,
                        const std::vector<consts::FieldMetadata>& fieldMetadataVec,
                        const std::string& filePath,
                        const bool isLfricNaming = true);
+
+  void writeState(const atlas::FieldSet& localFieldSet,
+                  const std::vector<consts::FieldMetadata>& fieldMetadataVec,
+                  const std::string& filePath,
+                  const bool isLfricNaming = true);
 
   void writeFieldSet(const atlas::FieldSet& localFieldSet,
                      const std::string& filePath);

--- a/src/monio/Monio.h
+++ b/src/monio/Monio.h
@@ -33,7 +33,6 @@ class Monio {
   Monio& operator=(Monio&&)      = delete;  //!< Deleted move assignment
   Monio& operator=(const Monio&) = delete;  //!< Deleted copy assignment
 
-
   int initialiseFile(const atlas::Grid& grid,
                      const std::string& filePath,
                      const util::DateTime& dateTime);  // Public, whilst called from LFRic-Lite
@@ -59,6 +58,9 @@ class Monio {
 
   void writeFieldSet(const atlas::FieldSet& localFieldSet,
                      const std::string& filePath);
+
+  // Called as part of exception handling in an attempt to free resources
+  void closeFiles();
 
  private:
   Monio(const eckit::mpi::Comm& mpiCommunicator,

--- a/src/monio/Reader.cc
+++ b/src/monio/Reader.cc
@@ -57,8 +57,15 @@ void monio::Reader::openFile(const std::string& filePath) {
 void monio::Reader::closeFile() {
   oops::Log::debug() << "Reader::closeFile()" << std::endl;
   if (mpiCommunicator_.rank() == mpiRankOwner_) {
-    file_->close();
+    if (isOpen() == true) {
+      getFile().close();
+      file_.release();
+    }
   }
+}
+
+bool monio::Reader::isOpen() {
+  return file_ != nullptr;
 }
 
 void monio::Reader::readMetadata(FileData& fileData) {
@@ -219,7 +226,7 @@ void monio::Reader::readFullDatum(FileData& fileData,
 
 monio::File& monio::Reader::getFile() {
   oops::Log::debug() << "Reader::getFile()" << std::endl;
-  if (file_ == nullptr) {
+  if (isOpen() == false) {
     utils::throwException("Reader::getFile()> File has not been initialised...");
   }
   return *file_;

--- a/src/monio/Reader.h
+++ b/src/monio/Reader.h
@@ -40,6 +40,7 @@ class Reader {
 
   void openFile(const std::string& filePath);
   void closeFile();
+  bool isOpen();
 
   void readMetadata(FileData& fileData);
 

--- a/src/monio/UtilsAtlas.cc
+++ b/src/monio/UtilsAtlas.cc
@@ -196,5 +196,28 @@ int atlasTypeToMonioEnum(atlas::array::DataType atlasType) {
     utils::throwException("utilsatlas::atlasTypeToMonioEnum()> Data type not coded for...");
   }
 }
+
+bool compareFieldSets(const atlas::FieldSet& aSet, const atlas::FieldSet& bSet) {
+  for (auto& a : aSet) {
+    if (compareFields(a, bSet[a.name()]) == false) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool compareFields(const atlas::Field& a, const atlas::Field& b) {
+  const auto aView = atlas::array::make_view<const double, 2>(a);
+  const auto bView = atlas::array::make_view<const double, 2>(b);
+  std::vector<int> dimVec = a.shape();
+  for (int j = 0; j < dimVec[consts::eVertical]; ++j) {
+    for (int i = 0; i < dimVec[consts::eHorizontal]; ++i) {
+      if (aView(i, j) != bView(i, j)) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
 }  // namespace utilsatlas
 }  // namespace monio

--- a/src/monio/UtilsAtlas.h
+++ b/src/monio/UtilsAtlas.h
@@ -46,5 +46,8 @@ namespace utilsatlas {
   int getGlobalDataSize(const atlas::Field& field);  // Full 3D size of data. Global fields only
 
   int atlasTypeToMonioEnum(atlas::array::DataType atlasType);
+
+  bool compareFieldSets(const atlas::FieldSet& aSet, const atlas::FieldSet& bSet);
+  bool compareFields(const atlas::Field& a, const atlas::Field& b);
 }  // namespace utilsatlas
 }  // namespace monio

--- a/src/monio/Variable.cc
+++ b/src/monio/Variable.cc
@@ -15,6 +15,7 @@
 #include "AttributeInt.h"
 #include "AttributeString.h"
 #include "Constants.h"
+#include "Monio.h"
 #include "Utils.h"
 
 monio::Variable::Variable(const std::string name, const int type):
@@ -67,6 +68,7 @@ std::shared_ptr<monio::AttributeBase>
   if (attributes_.find(attrName) != attributes_.end()) {
     return attributes_.at(attrName);
   } else {
+    Monio::get().closeFiles();
     utils::throwException("Variable::getAttribute()> Attribute \"" +
                                     attrName + "\" not found...");
   }
@@ -83,15 +85,16 @@ std::string monio::Variable::getStrAttr(const std::string& attrName) {
       value = attrStr->getValue();
       return value;
     } else {
-      // Does not currently handle AttributeInt types. Used specifically to retrieve LFRic's
-      // "standard_type" variable attributes as the closest approximation to a JEDI variable name.
-      // These are stored as AttributeString.
+      // Used specifically to retrieve LFRic's "standard_type" variable attributes as the closest
+      // approximation to a JEDI variable name. These are stored as AttributeString.
+      Monio::get().closeFiles();
       utils::throwException("Variable::getAttribute()> "
           "Variable attribute data type not coded for...");
     }
   } else {
+    Monio::get().closeFiles();
     utils::throwException("Variable::getAttribute()> Attribute \"" +
-                                    attrName + "\" not found...");
+                          attrName + "\" not found...");
   }
 }
 
@@ -102,8 +105,9 @@ void monio::Variable::addDimension(const std::string& dimName, const size_t size
   if (it == dimensions_.end()) {
     dimensions_.push_back(std::make_pair(dimName, size));
   } else {
-      utils::throwException("Variable::addDimension()> Dimension \"" +
-                                    dimName + "\" already defined...");
+    Monio::get().closeFiles();
+    utils::throwException("Variable::addDimension()> Dimension \"" +
+                          dimName + "\" already defined...");
   }
 }
 
@@ -113,8 +117,9 @@ void monio::Variable::addAttribute(std::shared_ptr<monio::AttributeBase> attr) {
   if (it == attributes_.end()) {
     attributes_.insert(std::make_pair(attrName, attr));
   } else {
+    Monio::get().closeFiles();
     utils::throwException("Variable::addAttribute()>  multiple definitions of \"" +
-                                attrName + "\"...");
+                          attrName + "\"...");
   }
 }
 
@@ -133,8 +138,9 @@ void monio::Variable::deleteAttribute(const std::string& attrName) {
   if (it != attributes_.end()) {
     attributes_.erase(attrName);
   } else {
-      utils::throwException("Variable::deleteAttribute()> Attribute \"" +
-                                    attrName + "\" does not exist...");
+    Monio::get().closeFiles();
+    utils::throwException("Variable::deleteAttribute()> Attribute \"" +
+                          attrName + "\" does not exist...");
   }
 }
 
@@ -146,8 +152,9 @@ size_t monio::Variable::getDimension(const std::string& dimName) {
   if (it != dimensions_.end()) {
     return it->second;
   } else {
-      utils::throwException("Variable::getDimension()> Dimension \"" +
-                                    dimName + "\" does not exist...");
+    Monio::get().closeFiles();
+    utils::throwException("Variable::getDimension()> Dimension \"" +
+                                  dimName + "\" does not exist...");
   }
 }
 

--- a/src/monio/Writer.cc
+++ b/src/monio/Writer.cc
@@ -53,9 +53,15 @@ void monio::Writer::openFile(const std::string& filePath) {
 void monio::Writer::closeFile() {
   oops::Log::debug() << "Writer::closeFile()" << std::endl;
   if (mpiCommunicator_.rank() == mpiRankOwner_) {
-    file_->close();
-    file_.release();
+    if (isOpen() == true) {
+      getFile().close();
+      file_.release();
+    }
   }
+}
+
+bool monio::Writer::isOpen() {
+  return file_ != nullptr;
 }
 
 void monio::Writer::writeMetadatum(const Metadata& metadata) {
@@ -112,7 +118,7 @@ void monio::Writer::writeData(const FileData& fileData) {
 
 monio::File& monio::Writer::getFile() {
   oops::Log::debug() << "Writer::getFile()" << std::endl;
-  if (file_ == nullptr) {
+  if (isOpen() == false) {
     utils::throwException("Writer::getFile()> File has not been initialised...");
   }
   return *file_;

--- a/src/monio/Writer.h
+++ b/src/monio/Writer.h
@@ -40,6 +40,7 @@ class Writer {
 
   void openFile(const std::string& filePath);
   void closeFile();
+  bool isOpen();
 
   void writeMetadatum(const Metadata& metadata);
   void writeDatum(const FileData& fileData);

--- a/test/monio/StateFull.h
+++ b/test/monio/StateFull.h
@@ -80,6 +80,8 @@ void readOutput(atlas::FieldSet& fieldSet,
   oops::Log::info() << "monio::test::readOutput()" << std::endl;
   oops::Log::info() << "filePath> " << filePath << std::endl;
 
+  // Since Atlas Fields do not contain a time dimension, the output file adopts the same format as
+  // an increment file. For this reason it is read as such.
   Monio::get().readIncrements(fieldSet, fieldMetadataVec, filePath);
 }
 

--- a/test/monio/StateFull.h
+++ b/test/monio/StateFull.h
@@ -156,7 +156,8 @@ void main() {
   std::string inputFilePath;
   std::string outputFilePath;
 
-  initParams(firstFieldSet, secondFieldSet, fieldMetadataVec, dateTime, inputFilePath, outputFilePath);
+  initParams(firstFieldSet, secondFieldSet, fieldMetadataVec,
+             dateTime, inputFilePath, outputFilePath);
   readInput(firstFieldSet, fieldMetadataVec, dateTime, inputFilePath);
   write(firstFieldSet, fieldMetadataVec, outputFilePath);
   readOutput(secondFieldSet, fieldMetadataVec, outputFilePath);

--- a/test/monio/StateFull.h
+++ b/test/monio/StateFull.h
@@ -57,9 +57,12 @@ atlas::FieldSet createFieldSet(const atlas::functionspace::CubedSphereNodeColumn
   oops::Log::debug() << "monio::test::createFieldSet()" << std::endl;
   atlas::FieldSet fieldSet;
   for (const auto& fieldMetadata : fieldMetadataVec) {
+    // To mimic JEDI's behaviour fields full or half fields are initialised with 70 levels
+    int numLevels = fieldMetadata.numberOfLevels == consts::kVerticalFullSize ?
+                    consts::kVerticalHalfSize : fieldMetadata.numberOfLevels;
     // No error checking on metadata. This is handled by calls to Monio
     atlas::util::Config atlasOptions = atlas::option::name(fieldMetadata.jediName) |
-                                       atlas::option::levels(fieldMetadata.numberOfLevels);
+                                       atlas::option::levels(numLevels);
     fieldSet.add(functionSpace.createField<double>(atlasOptions));
   }
   return fieldSet;

--- a/test/monio/StateFull.h
+++ b/test/monio/StateFull.h
@@ -26,6 +26,7 @@
 #include "monio/Constants.h"
 #include "monio/Monio.h"
 #include "monio/Utils.h"
+#include "monio/UtilsAtlas.h"
 
 #include "oops/../test/TestEnvironment.h"
 #include "oops/runs/Test.h"
@@ -64,36 +65,49 @@ atlas::FieldSet createFieldSet(const atlas::functionspace::CubedSphereNodeColumn
   return fieldSet;
 }
 
-void compare() {
+void compare(atlas::FieldSet& firstFieldSet, atlas::FieldSet& secondFieldSet) {
   oops::Log::info() << "monio::test::compare()" << std::endl;
+
+  if (utilsatlas::compareFieldSets(firstFieldSet, secondFieldSet) == false) {
+    utils::throwException("FieldSets do not match...");
+  }
 }
 
 /// Reads
-void readOutput(const std::string& outputFilePath) {
+void readOutput(atlas::FieldSet& fieldSet,
+                const std::vector<consts::FieldMetadata>& fieldMetadataVec,
+                const std::string& filePath) {
   oops::Log::info() << "monio::test::readOutput()" << std::endl;
-  oops::Log::info() << "outputFilePath> " << outputFilePath << std::endl;
+  oops::Log::info() << "filePath> " << filePath << std::endl;
+
+  Monio::get().readIncrements(fieldSet, fieldMetadataVec, filePath);
 }
 
 /// Writes FieldSet to file.
-void write(const std::string& outputFilePath) {
+void write(const atlas::FieldSet& fieldSet,
+           const std::vector<consts::FieldMetadata>& fieldMetadataVec,
+           const std::string& filePath) {
   oops::Log::info() << "monio::test::write()" << std::endl;
-  oops::Log::info() << "outputFilePath> " << outputFilePath << std::endl;
+  oops::Log::info() << "filePath> " << filePath << std::endl;
+
+  Monio::get().writeState(fieldSet, fieldMetadataVec, filePath);
 }
 
 /// Reads data from file and populates the FieldSet
 void readInput(atlas::FieldSet& fieldSet,
                const std::vector<consts::FieldMetadata>& fieldMetadataVec,
                const util::DateTime& dateTime,
-               const std::string& inputFilePath) {
+               const std::string& filePath) {
   oops::Log::info() << "monio::test::readInput()" << std::endl;
-  oops::Log::info() << "inputFilePath> " << inputFilePath << std::endl;
+  oops::Log::info() << "filePath> " << filePath << std::endl;
   oops::Log::info() << "dateTime> " << dateTime << std::endl;
 
-  Monio::get().readState(fieldSet, fieldMetadataVec, inputFilePath, dateTime);
+  Monio::get().readState(fieldSet, fieldMetadataVec, filePath, dateTime);
 }
 
 /// Sets up the objects required to mimic an operational call to Monio::Read via readInput
-void initParams(atlas::FieldSet& fieldSet,
+void initParams(atlas::FieldSet& firstFieldSet,
+                atlas::FieldSet& secondFieldSet,
                 std::vector<consts::FieldMetadata>& fieldMetadataVec,
                 util::DateTime& dateTime,
                 std::string& inputFilePath,
@@ -126,7 +140,8 @@ void initParams(atlas::FieldSet& fieldSet,
 
     fieldMetadataVec.push_back(fieldMetadata);
   }
-  fieldSet = createFieldSet(functionSpace, fieldMetadataVec);
+  firstFieldSet = createFieldSet(functionSpace, fieldMetadataVec);
+  secondFieldSet = createFieldSet(functionSpace, fieldMetadataVec);
   // Others
   dateTime = util::DateTime(paramConfig.getString("dateTime"));
   inputFilePath = paramConfig.getString("inputFilePath");
@@ -134,16 +149,18 @@ void initParams(atlas::FieldSet& fieldSet,
 }
 
 void main() {
-  atlas::FieldSet fieldSet;
+  atlas::FieldSet firstFieldSet;
+  atlas::FieldSet secondFieldSet;
   std::vector<consts::FieldMetadata> fieldMetadataVec;
   util::DateTime dateTime;
   std::string inputFilePath;
   std::string outputFilePath;
 
-  initParams(fieldSet, fieldMetadataVec, dateTime, inputFilePath, outputFilePath);
-  readInput(fieldSet, fieldMetadataVec, dateTime, inputFilePath);
-  write(outputFilePath);
-  readOutput(outputFilePath);
+  initParams(firstFieldSet, secondFieldSet, fieldMetadataVec, dateTime, inputFilePath, outputFilePath);
+  readInput(firstFieldSet, fieldMetadataVec, dateTime, inputFilePath);
+  write(firstFieldSet, fieldMetadataVec, outputFilePath);
+  readOutput(secondFieldSet, fieldMetadataVec, outputFilePath);
+  compare(firstFieldSet, secondFieldSet);
 }
 
 class StateFull : public oops::Test{

--- a/test/testinput/state_basic.yaml
+++ b/test/testinput/state_basic.yaml
@@ -1,3 +1,3 @@
 filePaths:
   inputFilePath: Data/lfricdiag/lfric_ops_C12L71_220609.nc
-  outputFilePath: DataOut/test_monio_netcdf_write_output.nc
+  outputFilePath: DataOut/test_monio_state_basic_output.nc

--- a/test/testinput/state_full.yaml
+++ b/test/testinput/state_full.yaml
@@ -1,10 +1,10 @@
 parameters:
   fieldMetadata:
-    exner:                    exner,                    exner_levels_minus_one, exner_levels_minus_one, 1,    70, false
-    grid_surface_temperature: grid_surface_temperature, skin_temperature,       skin_temperature,       K,    1,  false
-    theta:                    theta,                    potential_temperature,  potential_temperature,  K,    71, true
-    u_in_w3:                  u_in_w3,                  eastward_wind,          eastward_wind,          ms-1, 70, false
-    v_in_w3:                  v_in_w3,                  northward_wind,         northward_wind,         ms-1, 70, false
+    exner:                    exner,                    exner,                    exner_levels_minus_one, 1,    70, false
+    grid_surface_temperature: grid_surface_temperature, grid_surface_temperature, skin_temperature,       K,    1,  false
+    theta:                    theta,                    theta,                    potential_temperature,  K,    71, false
+    u_in_w3:                  u_in_w3,                  u_in_w3,                  eastward_wind,          ms-1, 70, false
+    v_in_w3:                  v_in_w3,                  v_in_w3,                  northward_wind,         ms-1, 70, false
   gridName: CS-LFR-224
   partitionerType: cubedsphere
   meshType: cubedsphere_dual

--- a/test/testinput/state_full.yaml
+++ b/test/testinput/state_full.yaml
@@ -11,4 +11,4 @@ parameters:
   meshType: cubedsphere_dual
   dateTime: 2021-06-01T23:00:00Z
   inputFilePath: Data/lfricdiag/lfric_bg_for_hofx_C224.nc
-  outputFilePath: DataOut/test_monio_read_write_output.nc
+  outputFilePath: DataOut/test_monio_state_full_output.nc

--- a/test/testinput/state_full.yaml
+++ b/test/testinput/state_full.yaml
@@ -2,7 +2,8 @@ parameters:
   fieldMetadata:
     exner:                    exner,                    exner,                    exner_levels_minus_one, 1,    70, false
     grid_surface_temperature: grid_surface_temperature, grid_surface_temperature, skin_temperature,       K,    1,  false
-    theta:                    theta,                    theta,                    potential_temperature,  K,    71, false
+    pressure_in_wth:          pressure_in_wth,          pressure_in_wth,          air_presssure,          Pa,   71, false
+    theta:                    theta,                    theta,                    potential_temperature,  K,    71, true
     u_in_w3:                  u_in_w3,                  u_in_w3,                  eastward_wind,          ms-1, 70, false
     v_in_w3:                  v_in_w3,                  v_in_w3,                  northward_wind,         ms-1, 70, false
   gridName: CS-LFR-224


### PR DESCRIPTION
Modifications to complete the set of tests within `test_monio_state_full`. This includes completion of the `Monio::writeState()` function and comparison of the output data with that first read in using a new `UtilsAtlas::compareFieldSets()` function.

Added additional closure of files when throwing exceptions in applicable places. This included a new public `Monio::closeFiles()` method and a check (`::isOpen()`) inside `Writer::closeFile()` and `Reader::closeFile()` to ensure the file is open before closing. This might not be necessary, but in theory it should free disk resources and allow executables to end more quickly following an I/O exception.

MONIO test outputs: http://fcm1/cylc-review/taskjobs/punderwo/?suite=monio_full_test_01

Due to the changes potentially affecting LFRic-Lite/JEDI. The code was tested there also:
http://fcm1/cylc-review/taskjobs/punderwo/?suite=lfricj_monio_full_test_02
http://fcm1/cylc-review/taskjobs/punderwo/?suite=llj_monio_full_test_03