### PR TITLE
Bugfix MONIO Issues

### DIFF
--- a/src/monio/AtlasReader.cc
+++ b/src/monio/AtlasReader.cc
@@ -10,7 +10,6 @@
 
 #include "oops/util/Logger.h"
 
-#include "Monio.h"
 #include "Utils.h"
 #include "UtilsAtlas.h"
 
@@ -60,7 +59,6 @@ void monio::AtlasReader::populateFieldWithDataContainer(atlas::Field& field,
       break;
     }
     default: {
-        Monio::get().closeFiles();
         utils::throwException("AtlasReader::populateFieldWithDataContainer()> "
                                  "Data type not coded for...");
       }
@@ -93,7 +91,6 @@ void monio::AtlasReader::populateFieldWithDataContainer(atlas::Field& field,
       break;
     }
     default: {
-        Monio::get().closeFiles();
         utils::throwException("AtlasReader::populateFieldWithDataContainer()> "
                                  "Data type not coded for...");
       }
@@ -110,7 +107,6 @@ void monio::AtlasReader::populateField(atlas::Field& field,
   auto fieldView = atlas::array::make_view<T, 2>(field);
   // Field with noFirstLevel == true should have been adjusted to have 70 levels.
   if (noFirstLevel == true && field.levels() == consts::kVerticalFullSize) {
-    Monio::get().closeFiles();
     utils::throwException("AtlasReader::populateField()> Field levels misconfiguration...");
   // Only valid case for field with noFirstLevel == true. Field is adjusted to have 70 levels but
   // read data still has enough to fill 71.
@@ -122,7 +118,6 @@ void monio::AtlasReader::populateField(atlas::Field& field,
         if (std::size_t(index) <= dataVec.size()) {
           fieldView(i, j - 1) = dataVec[index];
         } else {
-          Monio::get().closeFiles();
           utils::throwException("AtlasReader::populateField()> Calculated index exceeds size of "
                                 "data for field \"" + field.name() + "\".");
         }
@@ -137,7 +132,6 @@ void monio::AtlasReader::populateField(atlas::Field& field,
         if (std::size_t(index) <= dataVec.size()) {
           fieldView(i, j) = dataVec[index];
         } else {
-          Monio::get().closeFiles();
           utils::throwException("AtlasReader::populateField()> Calculated index exceeds size of "
                                 "data for field \"" + field.name() + "\".");
         }
@@ -176,7 +170,6 @@ void monio::AtlasReader::populateField(atlas::Field& field,
       if (std::size_t(index) <= dataVec.size()) {
         fieldView(i, j) = dataVec[index];
       } else {
-        Monio::get().closeFiles();
         utils::throwException("AtlasReader::populateField()> "
                               "Calculated index exceeds size of data.");
       }
@@ -199,7 +192,6 @@ atlas::Field monio::AtlasReader::getReadField(atlas::Field& field,
     if (atlasType != atlasType.KIND_REAL64 &&
         atlasType != atlasType.KIND_REAL32 &&
         atlasType != atlasType.KIND_INT32) {
-        Monio::get().closeFiles();
         utils::throwException("AtlasReader::getReadField())> Data type not coded for...");
     }
     atlas::util::Config atlasOptions = atlas::option::name(field.name()) |

--- a/src/monio/AtlasWriter.cc
+++ b/src/monio/AtlasWriter.cc
@@ -17,7 +17,6 @@
 #include "DataContainerFloat.h"
 #include "DataContainerInt.h"
 #include "Metadata.h"
-#include "Monio.h"
 #include "Utils.h"
 #include "UtilsAtlas.h"
 #include "Writer.h"
@@ -203,7 +202,6 @@ void monio::AtlasWriter::populateDataContainerWithField(
         break;
       }
       default: {
-        Monio::get().closeFiles();
         utils::throwException("AtlasWriter::populateDataContainerWithField()> "
                                  "Data type not coded for...");
       }
@@ -256,7 +254,6 @@ void monio::AtlasWriter::populateDataContainerWithField(
       break;
     }
     default: {
-        Monio::get().closeFiles();
         utils::throwException("AtlasWriter::populateDataContainerWithField()> "
                                  "Data type not coded for...");
       }
@@ -271,7 +268,6 @@ void monio::AtlasWriter::populateDataVec(std::vector<T>& dataVec,
   oops::Log::debug() << "AtlasWriter::populateDataVec() " << field.name() << std::endl;
   int numLevels = field.levels();
   if ((lfricToAtlasMap.size() * numLevels) != dataVec.size()) {
-    Monio::get().closeFiles();
     utils::throwException("AtlasWriter::populateDataVec()> "
                           "Data container is not configured for the expected data...");
   }
@@ -327,12 +323,10 @@ atlas::Field monio::AtlasWriter::getWriteField(atlas::Field& field,
   if (atlasType != atlasType.KIND_REAL64 &&
       atlasType != atlasType.KIND_REAL32 &&
       atlasType != atlasType.KIND_INT32) {
-      Monio::get().closeFiles();
       utils::throwException("AtlasWriter::getWriteField())> Data type not coded for...");
   }
   // Erroneous case. For noFirstLevel == true field should have 70 levels
   if (noFirstLevel == true && field.levels() == consts::kVerticalFullSize) {
-    Monio::get().closeFiles();
     utils::throwException("AtlasWriter::getWriteField()> Field levels misconfiguration...");
   }
   // WARNING - This name-check is an LFRic-Lite specific convention...
@@ -356,7 +350,6 @@ atlas::Field monio::AtlasWriter::getWriteField(atlas::Field& field,
       field.metadata().set("name", writeName);
     }
   } else {
-    Monio::get().closeFiles();
     utils::throwException("AtlasWriter::getWriteField()> Field write name misconfiguration...");
   }
   return field;

--- a/src/monio/Data.cc
+++ b/src/monio/Data.cc
@@ -17,7 +17,6 @@
 #include "DataContainerDouble.h"
 #include "DataContainerFloat.h"
 #include "DataContainerInt.h"
-#include "Monio.h"
 #include "Utils.h"
 
 namespace {
@@ -143,7 +142,6 @@ std::shared_ptr<monio::DataContainerBase>
   if (it != dataContainers_.end()) {
     return it->second;
   } else {
-    Monio::get().closeFiles();
     utils::throwException("DataContainer named \"" + name + "\" was not found.");
   }
 }

--- a/src/monio/DataContainerDouble.cc
+++ b/src/monio/DataContainerDouble.cc
@@ -11,7 +11,6 @@
 #include <stdexcept>
 
 #include "Constants.h"
-#include "Monio.h"
 #include "Utils.h"
 
 monio::DataContainerDouble::DataContainerDouble(const std::string& name) :
@@ -31,7 +30,6 @@ const std::vector<double>& monio::DataContainerDouble::getData() const {
 
 const double& monio::DataContainerDouble::getDatum(const size_t index) {
   if (index > dataVector_.size()) {
-    Monio::get().closeFiles();
     utils::throwException("DataContainerDouble::getDatum()> Passed index exceeds vector size...");
   }
 

--- a/src/monio/DataContainerFloat.cc
+++ b/src/monio/DataContainerFloat.cc
@@ -11,7 +11,6 @@
 #include <stdexcept>
 
 #include "Constants.h"
-#include "Monio.h"
 #include "Utils.h"
 
 monio::DataContainerFloat::DataContainerFloat(const std::string& name) :
@@ -31,7 +30,6 @@ const std::vector<float>& monio::DataContainerFloat::getData() const {
 
 const float& monio::DataContainerFloat::getDatum(const size_t index) {
   if (index > dataVector_.size()) {
-    Monio::get().closeFiles();
     utils::throwException("DataContainerFloat::getDatum()> Passed index exceeds vector size...");
   }
   return dataVector_[index];

--- a/src/monio/DataContainerInt.cc
+++ b/src/monio/DataContainerInt.cc
@@ -11,7 +11,6 @@
 #include <stdexcept>
 
 #include "Constants.h"
-#include "Monio.h"
 #include "Utils.h"
 
 monio::DataContainerInt::DataContainerInt(const std::string& name) :
@@ -31,7 +30,6 @@ const std::vector<int>& monio::DataContainerInt::getData() const {
 
 const int& monio::DataContainerInt::getDatum(const size_t index) {
   if (index > dataVector_.size()) {
-    Monio::get().closeFiles();
     utils::throwException("DataContainerInt::getDatum()> Passed index exceeds vector size...");
   }
   return dataVector_[index];

--- a/src/monio/Metadata.cc
+++ b/src/monio/Metadata.cc
@@ -20,7 +20,6 @@
 #include "AttributeDouble.h"
 #include "AttributeInt.h"
 #include "AttributeString.h"
-#include "Monio.h"
 #include "Utils.h"
 
 monio::Metadata::Metadata() {
@@ -143,7 +142,6 @@ int monio::Metadata::getDimension(const std::string& dimName) {
   if (isDimDefined(dimName) == true) {
     return dimensions_.at(dimName);
   } else {
-    Monio::get().closeFiles();
     utils::throwException("Metadata::getDimension()> dimension \"" + dimName + "\" not found...");
   }
 }
@@ -172,7 +170,6 @@ std::shared_ptr<monio::Variable> monio::Metadata::getVariable(const std::string&
   if (it != variables_.end()) {
     return variables_.at(varName);
   } else {
-    Monio::get().closeFiles();
     utils::throwException("Metadata::getVariable()> variable \"" + varName + "\" not found...");
   }
 }
@@ -185,7 +182,6 @@ const std::shared_ptr<monio::Variable>
   if (it != variables_.end()) {
     return variables_.at(varName);
   } else {
-    Monio::get().closeFiles();
     utils::throwException("Metadata::getVariable()> variable \"" + varName + "\" not found...");
   }
 }
@@ -227,7 +223,6 @@ const std::vector<std::string> monio::Metadata::getVarStrAttrs(
       varStrAttrs.push_back(attr);
   }
   if (varNames.size() != varStrAttrs.size()) {
-    Monio::get().closeFiles();
     utils::throwException("Metadata::getVarStrAttrs()> "
         "Unmatched number of variables and attributes...");
   }
@@ -366,7 +361,6 @@ void monio::Metadata::deleteVariable(const std::string& varName) {
   if (it != variables_.end()) {
     variables_.erase(varName);
   } else {
-    Monio::get().closeFiles();
     utils::throwException("Metadata::deleteVariable()> Variable \"" + varName + "\" not found...");
   }
 }
@@ -438,7 +432,6 @@ void monio::Metadata::printVariables() {
           break;
         }
         default: {
-          Monio::get().closeFiles();
           utils::throwException("Metadata::printGlobalAttrs()> Data type not coded for...");
         }
       }
@@ -471,7 +464,6 @@ void monio::Metadata::printGlobalAttrs() {
         break;
       }
       default: {
-        Monio::get().closeFiles();
         utils::throwException("Metadata::printGlobalAttrs()> Data type not coded for...");
       }
     }

--- a/src/monio/Monio.cc
+++ b/src/monio/Monio.cc
@@ -164,7 +164,7 @@ void monio::Monio::writeIncrements(const atlas::FieldSet& localFieldSet,
       cleanFileData(fileData);
       writer_.openFile(filePath);
       for (const auto& fieldMetadata : fieldMetadataVec) {
-        auto& localField = localFieldSet["fieldMetadata.jediName"];
+        auto& localField = localFieldSet[fieldMetadata.jediName];
         atlas::Field globalField = utilsatlas::getGlobalField(localField);
         if (mpiCommunicator_.rank() == mpiRankOwner_) {
           // Configure write name

--- a/src/monio/Monio.h
+++ b/src/monio/Monio.h
@@ -66,7 +66,7 @@ class Monio {
   void writeFieldSet(const atlas::FieldSet& localFieldSet,
                      const std::string& filePath);
 
-  /// \brief Called when handling exceptions elsewhere in MONIO to free disk resources more quickly.
+  /// \brief Can be called elsewhere in MONIO to free disk resources more quickly.
   void closeFiles();
 
   /// \brief A call to open and initialise a state file for reading. This function is public whilst

--- a/src/monio/Variable.cc
+++ b/src/monio/Variable.cc
@@ -15,7 +15,6 @@
 #include "AttributeInt.h"
 #include "AttributeString.h"
 #include "Constants.h"
-#include "Monio.h"
 #include "Utils.h"
 
 monio::Variable::Variable(const std::string name, const int type):
@@ -60,7 +59,6 @@ std::shared_ptr<monio::AttributeBase>
   if (attributes_.find(attrName) != attributes_.end()) {
     return attributes_.at(attrName);
   } else {
-    Monio::get().closeFiles();
     utils::throwException("Variable::getAttribute()> Attribute \"" +
                                     attrName + "\" not found...");
   }
@@ -77,12 +75,10 @@ std::string monio::Variable::getStrAttr(const std::string& attrName) {
       value = attrStr->getValue();
       return value;
     } else {
-      Monio::get().closeFiles();
       utils::throwException("Variable::getAttribute()> "
           "Variable attribute data type not coded for...");
     }
   } else {
-    Monio::get().closeFiles();
     utils::throwException("Variable::getAttribute()> Attribute \"" +
                           attrName + "\" not found...");
   }
@@ -95,7 +91,6 @@ void monio::Variable::addDimension(const std::string& dimName, const size_t size
   if (it == dimensions_.end()) {
     dimensions_.push_back(std::make_pair(dimName, size));
   } else {
-    Monio::get().closeFiles();
     utils::throwException("Variable::addDimension()> Dimension \"" +
                           dimName + "\" already defined...");
   }
@@ -107,7 +102,6 @@ void monio::Variable::addAttribute(std::shared_ptr<monio::AttributeBase> attr) {
   if (it == attributes_.end()) {
     attributes_.insert(std::make_pair(attrName, attr));
   } else {
-    Monio::get().closeFiles();
     utils::throwException("Variable::addAttribute()> multiple definitions of \"" +
                           attrName + "\"...");
   }
@@ -128,7 +122,6 @@ void monio::Variable::deleteAttribute(const std::string& attrName) {
   if (it != attributes_.end()) {
     attributes_.erase(attrName);
   } else {
-    Monio::get().closeFiles();
     utils::throwException("Variable::deleteAttribute()> Attribute \"" +
                           attrName + "\" does not exist...");
   }


### PR DESCRIPTION
A piece of testing code was left in by mistake. This has been removed. It was also found that the new file closure function `Monio::closeFiles` was causing issues somehow. It's unclear how this can cause tests to fail, since it was only called when exceptions were generated - so the test would have failed anyway. However, removing these recent additions to the code have apparently fixed the issue.

Current test outputs: http://fcm1/cylc-review/taskjobs/punderwo/?suite=llj_monio_bugfix_02