### PR TITLE
Add `kMissingVariableName = "none"` for lfric-jedi

### DIFF
--- a/src/monio/AtlasWriter.cc
+++ b/src/monio/AtlasWriter.cc
@@ -330,7 +330,7 @@ atlas::Field monio::AtlasWriter::getWriteField(atlas::Field& field,
     utils::throwException("AtlasWriter::getWriteField()> Field levels misconfiguration...");
   }
   // WARNING - This name-check is an LFRic-Lite specific convention...
-  if (writeName != consts::kToBeDerived && writeName != consts::kToBeImplemented) {
+  if (utils::findInVector(consts::kMissingVariableNames, writeName) == false) {
     if (noFirstLevel == true && field.levels() == consts::kVerticalHalfSize) {
       atlas::util::Config atlasOptions = atlas::option::name(writeName) |
                                          atlas::option::global(0) |

--- a/src/monio/Constants.h
+++ b/src/monio/Constants.h
@@ -114,9 +114,6 @@ const std::string_view kLatitudeVarName = "latitude";
 const std::string_view kTabSpace = "    ";
 const std::string_view kNotFoundError = "NOT_FOUND";
 
-const std::string_view kToBeDerived = "TO BE DERIVED";
-const std::string_view kToBeImplemented = "TO BE IMPLEMENTED";
-
 const std::string_view kProducedByName = "produced_by";
 const std::string_view kProducedByString = "MONIO: Met Office NetCDF I/O";
 const std::string_view kNamingConventionName = "naming_convention";
@@ -170,6 +167,12 @@ const std::string_view  kIncrementVariableValues[eNumberOfAttributeNames] {
 const std::vector<std::string> kNamingConventions({
   "LFRic",
   "JEDI"
+});
+
+const std::vector<std::string> kMissingVariableNames({
+  "TO BE DERIVED",      // LFRic-Lite - variables without names in the LFRic context
+  "TO BE IMPLEMENTED",  // LFRic-Lite - theoretical variables that aren't used
+  "none"                // LFRic-JEDI
 });
 
 const std::vector<std::string> kLfricCoordVarNames = {std::string(kLfricLonVarName),


### PR DESCRIPTION
Checks for `"none"` when writing variables and throws an error (such as with "TO BE DERIVED", "TO BE IMPLEMENTED").

Change intended for JCSDA-internal/lfric-jedi/pull/640 but there is no strict dependency.

Testing: Tested with LFRic-JEDI JCSDA-internal/lfric-jedi/pull/640  -> [Job 3/4 of spice_gnu_debug](http://fcm1/cylc-review/taskjobs?user=jcolclou&suite=monio_inc_wr_231023&no_fuzzy_time=0&cycles=1&tasks=ctest_lfricjedi_3dvar_6__spice_gnu_debug&task_status=runahead&task_status=waiting&task_status=held&task_status=queued&task_status=expired&task_status=ready&task_status=submit-failed&task_status=submit-retrying&task_status=submitted&task_status=retrying&task_status=running&task_status=failed&task_status=succeeded&job_status=&order=time_desc&per_page=) fails due to the additional checking (expected behaviour).