### PR TITLE
Feature/levels metadata

### DIFF
--- a/src/monio/AtlasReader.h
+++ b/src/monio/AtlasReader.h
@@ -47,7 +47,8 @@ class AtlasReader {
   void populateFieldWithFileData(atlas::Field& field,
                            const FileData& fileData,
                            const consts::FieldMetadata& fieldMetadata,
-                           const std::string& readName);
+                           const std::string& readName,
+                           const bool isLfricConvention);
 
  private:
   /// \brief Called from the entry point. Derives container type, makes the call to populate a field
@@ -55,7 +56,8 @@ class AtlasReader {
   void populateFieldWithDataContainer(atlas::Field& field,
                                 const std::shared_ptr<monio::DataContainerBase>& dataContainer,
                                 const std::vector<size_t>& lfricToAtlasMap,
-                                const bool copyFirstLevel = false);
+                                const bool noFirstLevel,
+                                const bool isLfricConvention);
 
   /// \brief Not currently used, but could be. Derives container type, makes the call to populate a
   ///        field with data where data order isn't relevant.
@@ -67,7 +69,8 @@ class AtlasReader {
   template<typename T> void populateField(atlas::Field& field,
                                     const std::vector<T>& dataVec,
                                     const std::vector<size_t>& lfricToAtlasMap,
-                                    const bool copyFirstLevel);
+                                    const bool noFirstLevel,
+                                    const bool isLfricConvention);
 
   /// \brief Not currently used, but used to populate a field where data order isn't relevant.
   template<typename T> void populateField(atlas::Field& field,

--- a/src/monio/AtlasWriter.cc
+++ b/src/monio/AtlasWriter.cc
@@ -33,7 +33,7 @@ void monio::AtlasWriter::populateFileDataWithField(FileData& fileData,
                                                    atlas::Field& field,
                                              const consts::FieldMetadata& fieldMetadata,
                                              const std::string& writeName,
-                                             const bool isLfricNaming) {
+                                             const bool isLfricConvention) {
   oops::Log::debug() << "AtlasWriter::populateFileDataWithField()" << std::endl;
   if (mpiCommunicator_.rank() == mpiRankOwner_) {
     std::vector<size_t>& lfricAtlasMap = fileData.getLfricAtlasMap();
@@ -46,7 +46,7 @@ void monio::AtlasWriter::populateFileDataWithField(FileData& fileData,
     atlas::Field writeField = getWriteField(field, writeName, fieldMetadata.noFirstLevel);
     populateMetadataWithField(metadata, writeField, fieldMetadata, writeName);
     populateDataWithField(fileData.getData(), writeField, lfricAtlasMap, writeName);
-    addGlobalAttributes(metadata, isLfricNaming);
+    addGlobalAttributes(metadata, isLfricConvention);
   }
 }
 
@@ -410,15 +410,15 @@ void monio::AtlasWriter::addVariableDimensions(const atlas::Field& field,
   }
 }
 
-void monio::AtlasWriter::addGlobalAttributes(Metadata& metadata, const bool isLfricNaming) {
+void monio::AtlasWriter::addGlobalAttributes(Metadata& metadata, const bool isLfricConvention) {
   // Initialise variables
-  std::string namingConvention =
-      isLfricNaming == true ? consts::kNamingConventions[consts::eLfricNaming] :
+  std::string variableConvention =
+      isLfricConvention == true ? consts::kNamingConventions[consts::eLfricNaming] :
                               consts::kNamingConventions[consts::eJediNaming];
   // Create attribute objects
   std::shared_ptr<monio::AttributeString> namingAttr =
-      std::make_shared<AttributeString>(std::string(consts::kNamingConventionName),
-                                        namingConvention);
+      std::make_shared<AttributeString>(std::string(consts::kVariableConventionName),
+                                        variableConvention);
   std::shared_ptr<monio::AttributeString> producedByAttr =
       std::make_shared<AttributeString>(std::string(consts::kProducedByName),
                                         std::string(consts::kProducedByString));

--- a/src/monio/AtlasWriter.cc
+++ b/src/monio/AtlasWriter.cc
@@ -33,18 +33,20 @@ void monio::AtlasWriter::populateFileDataWithField(FileData& fileData,
                                                    atlas::Field& field,
                                              const consts::FieldMetadata& fieldMetadata,
                                              const std::string& writeName,
+                                             const std::string& vertConfigName,
                                              const bool isLfricConvention) {
   oops::Log::debug() << "AtlasWriter::populateFileDataWithField()" << std::endl;
   if (mpiCommunicator_.rank() == mpiRankOwner_) {
     std::vector<size_t>& lfricAtlasMap = fileData.getLfricAtlasMap();
     // Create dimensions
     Metadata& metadata = fileData.getMetadata();
-    metadata.addDimension(std::string(consts::kHorizontalName), lfricAtlasMap.size());
-    metadata.addDimension(std::string(consts::kVerticalFullName), consts::kVerticalFullSize);
-    metadata.addDimension(std::string(consts::kVerticalHalfName), consts::kVerticalHalfSize);
-
-    atlas::Field writeField = getWriteField(field, writeName, fieldMetadata.noFirstLevel);
-    populateMetadataWithField(metadata, writeField, fieldMetadata, writeName);
+    atlas::Field writeField;
+    if (isLfricConvention == true) {
+      writeField = getWriteField(field, writeName, fieldMetadata.noFirstLevel);
+    } else {
+      writeField = field;
+    }
+    populateMetadataWithField(metadata, writeField, fieldMetadata, writeName, vertConfigName);
     populateDataWithField(fileData.getData(), writeField, lfricAtlasMap, writeName);
     addGlobalAttributes(metadata, isLfricConvention);
   }
@@ -99,12 +101,15 @@ void monio::AtlasWriter::populateFileDataWithField(FileData& fileData,
 void monio::AtlasWriter::populateMetadataWithField(Metadata& metadata,
                                              const atlas::Field& field,
                                              const consts::FieldMetadata& fieldMetadata,
-                                             const std::string& varName) {
+                                             const std::string& varName,
+                                             const std::string& vertConfigName) {
   oops::Log::debug() << "AtlasWriter::populateMetadataWithField()" << std::endl;
   int type = utilsatlas::atlasTypeToMonioEnum(field.datatype());
   std::shared_ptr<monio::Variable> var = std::make_shared<Variable>(varName, type);
   // Variable dimensions
-  addVariableDimensions(field, metadata, var);
+  addVariableDimensions(field, metadata, var, vertConfigName);
+  int dimSize = metadata.getDimension(vertConfigName);
+  metadata.addDimension(vertConfigName, dimSize);
   // Variable attributes
   for (int i = 0; i < consts::eNumberOfAttributeNames; ++i) {
     std::string attributeName = std::string(consts::kIncrementAttributeNames[i]);
@@ -395,7 +400,8 @@ template atlas::Field monio::AtlasWriter::copySurfaceLevel<int>(const atlas::Fie
 
 void monio::AtlasWriter::addVariableDimensions(const atlas::Field& field,
                                                const Metadata& metadata,
-                                               std::shared_ptr<monio::Variable> var) {
+                                                     std::shared_ptr<monio::Variable> var,
+                                               const std::string& vertConfigName) {
   std::vector<int> dimVec = field.shape();
   if (field.metadata().get<bool>("global") == false) {
     dimVec[0] = utilsatlas::getHorizontalSize(field);  // If so, get the 2D size of the Field
@@ -403,7 +409,13 @@ void monio::AtlasWriter::addVariableDimensions(const atlas::Field& field,
   // Reversal of dims required for LFRic files. Currently applied to all output files.
   std::reverse(dimVec.begin(), dimVec.end());
   for (auto& dimSize : dimVec) {
-    std::string dimName = metadata.getDimensionName(dimSize);
+    std::string dimName;
+    int tmpSz = metadata.getDimension(vertConfigName);
+    if (vertConfigName != "" && dimSize == metadata.getDimension(vertConfigName)) {
+      dimName = vertConfigName;
+    } else {
+      dimName = metadata.getDimensionName(dimSize);
+    }
     if (dimName != consts::kNotFoundError) {  // Not used for 1-D fields.
       var->addDimension(dimName, dimSize);
     }

--- a/src/monio/AtlasWriter.cc
+++ b/src/monio/AtlasWriter.cc
@@ -413,8 +413,8 @@ void monio::AtlasWriter::addVariableDimensions(const atlas::Field& field,
 void monio::AtlasWriter::addGlobalAttributes(Metadata& metadata, const bool isLfricConvention) {
   // Initialise variables
   std::string variableConvention =
-      isLfricConvention == true ? consts::kNamingConventions[consts::eLfricNaming] :
-                              consts::kNamingConventions[consts::eJediNaming];
+      isLfricConvention == true ? consts::kNamingConventions[consts::eLfricConvention] :
+                              consts::kNamingConventions[consts::eJediConvention];
   // Create attribute objects
   std::shared_ptr<monio::AttributeString> namingAttr =
       std::make_shared<AttributeString>(std::string(consts::kVariableConventionName),

--- a/src/monio/AtlasWriter.cc
+++ b/src/monio/AtlasWriter.cc
@@ -108,8 +108,6 @@ void monio::AtlasWriter::populateMetadataWithField(Metadata& metadata,
   std::shared_ptr<monio::Variable> var = std::make_shared<Variable>(varName, type);
   // Variable dimensions
   addVariableDimensions(field, metadata, var, vertConfigName);
-  int dimSize = metadata.getDimension(vertConfigName);
-  metadata.addDimension(vertConfigName, dimSize);
   // Variable attributes
   for (int i = 0; i < consts::eNumberOfAttributeNames; ++i) {
     std::string attributeName = std::string(consts::kIncrementAttributeNames[i]);
@@ -410,8 +408,8 @@ void monio::AtlasWriter::addVariableDimensions(const atlas::Field& field,
   std::reverse(dimVec.begin(), dimVec.end());
   for (auto& dimSize : dimVec) {
     std::string dimName;
-    int tmpSz = metadata.getDimension(vertConfigName);
-    if (vertConfigName != "" && dimSize == metadata.getDimension(vertConfigName)) {
+    if (vertConfigName != "" && metadata.isDimDefined(vertConfigName) &&
+        dimSize == metadata.getDimension(vertConfigName)) {
       dimName = vertConfigName;
     } else {
       dimName = metadata.getDimensionName(dimSize);

--- a/src/monio/AtlasWriter.h
+++ b/src/monio/AtlasWriter.h
@@ -43,6 +43,7 @@ class AtlasWriter {
                                  atlas::Field& field,
                            const consts::FieldMetadata& fieldMetadata,
                            const std::string& writeName,
+                           const std::string& vertConfigName,
                            const bool isLfricConvention);
 
   /// \brief Creates all metadata and data from at Atlas field. For writing of field sets with no
@@ -57,7 +58,8 @@ class AtlasWriter {
   void populateMetadataWithField(Metadata& metadata,
                            const atlas::Field& field,
                            const consts::FieldMetadata& fieldMetadata,
-                           const std::string& varName);
+                           const std::string& varName,
+                           const std::string& vertConfigName);
 
   /// \brief Creates all metadata for field. Called from populateFileDataWithField where metadata
   ///        are created.
@@ -101,7 +103,7 @@ class AtlasWriter {
                                       const atlas::Field& field,
                                       const std::vector<int>& dimensions);
 
-  /// \brief Returns a field formatted for writing to file.
+  /// \brief  Map JEDI fields back into LFRic function space.
   atlas::Field getWriteField(atlas::Field& inputField,
                        const std::string& writeName,
                        const bool noFirstLevel);
@@ -116,7 +118,8 @@ class AtlasWriter {
   /// \brief Associates a given variable with its applicable dimensions in the metadata.
   void addVariableDimensions(const atlas::Field& field,
                              const Metadata& metadata,
-                                   std::shared_ptr<monio::Variable> var);
+                                   std::shared_ptr<monio::Variable> var,
+                             const std::string& vertConfigName = "");
 
   void addGlobalAttributes(Metadata& metadata, const bool isLfricConvention = true);
 

--- a/src/monio/AtlasWriter.h
+++ b/src/monio/AtlasWriter.h
@@ -43,7 +43,7 @@ class AtlasWriter {
                                  atlas::Field& field,
                            const consts::FieldMetadata& fieldMetadata,
                            const std::string& writeName,
-                           const bool isLfricNaming);
+                           const bool isLfricConvention);
 
   /// \brief Creates all metadata and data from at Atlas field. For writing of field sets with no
   ///        metadata.
@@ -118,7 +118,7 @@ class AtlasWriter {
                              const Metadata& metadata,
                                    std::shared_ptr<monio::Variable> var);
 
-  void addGlobalAttributes(Metadata& metadata, const bool isLfricNaming = true);
+  void addGlobalAttributes(Metadata& metadata, const bool isLfricConvention = true);
 
   const eckit::mpi::Comm& mpiCommunicator_;
   const std::size_t mpiRankOwner_;

--- a/src/monio/Constants.h
+++ b/src/monio/Constants.h
@@ -56,10 +56,10 @@ enum eDimensions {
   eVertical
 };
 
-/// \brief For indicating the naming convention adopted by input files, where applicable.
-enum eNamingConventions {
-  eLfricNaming,
-  eJediNaming,
+/// \brief For indicating the variable convention adopted by input files, where applicable.
+enum eVariableConventions {
+  eLfricConvention,
+  eJediConvention,
   eNotDefined
 };
 
@@ -120,7 +120,7 @@ const std::string_view kNotFoundError = "NOT_FOUND";
 
 const std::string_view kProducedByName = "produced_by";
 const std::string_view kProducedByString = "MONIO: Met Office NetCDF I/O";
-const std::string_view kVariableConventionName = "naming_convention";
+const std::string_view kVariableConventionName = "variable_convention";
 
 /// Multi-dimensional String/Views /////////////////////////////////////////////////////////////////
 

--- a/src/monio/Constants.h
+++ b/src/monio/Constants.h
@@ -61,9 +61,8 @@ enum eDimensions {
 
 /// \brief For indicating the variable convention adopted by input files, where applicable.
 enum eVariableConventions {
-  eJediConvention,
   eLfricConvention,
-  eNotDefined
+  eJediConvention
 };
 
 /// \brief Used for populating output files with the correct metadata associated with variable data.

--- a/src/monio/Constants.h
+++ b/src/monio/Constants.h
@@ -61,8 +61,8 @@ enum eDimensions {
 
 /// \brief For indicating the variable convention adopted by input files, where applicable.
 enum eVariableConventions {
-  eLfricConvention,
   eJediConvention,
+  eLfricConvention,
   eNotDefined
 };
 

--- a/src/monio/Constants.h
+++ b/src/monio/Constants.h
@@ -120,7 +120,7 @@ const std::string_view kNotFoundError = "NOT_FOUND";
 
 const std::string_view kProducedByName = "produced_by";
 const std::string_view kProducedByString = "MONIO: Met Office NetCDF I/O";
-const std::string_view kNamingConventionName = "naming_convention";
+const std::string_view kVariableConventionName = "naming_convention";
 
 /// Multi-dimensional String/Views /////////////////////////////////////////////////////////////////
 

--- a/src/monio/Constants.h
+++ b/src/monio/Constants.h
@@ -23,6 +23,8 @@ struct FieldMetadata {
   std::string lfricReadName;
   std::string lfricWriteName;
   std::string jediName;
+  std::string lfricVertConfig;
+  std::string jediVertConfig;
   std::string units;
   int numberOfLevels;
   bool noFirstLevel;
@@ -35,6 +37,8 @@ enum eFieldMetadata {
   eLfricReadName,
   eLfricWriteName,
   eJediName,
+  eLfricVertConfig,
+  eJediVertConfig,
   eUnits,
   eNumberOfLevels,
   eNoFirstLevel

--- a/src/monio/Constants.h
+++ b/src/monio/Constants.h
@@ -8,12 +8,15 @@
 ******************************************************************************/
 #pragma once
 
+#include <numeric>
 #include <string>
 #include <string_view>
 #include <vector>
 
 namespace monio {
 namespace consts {
+
+using std::iota;
 /// Structs ////////////////////////////////////////////////////////////////////////////////////////
 
 /// \brief This struct is used for interfacing with the Monio singleton and its intended use-cases
@@ -107,6 +110,8 @@ const std::string_view kTileVarName = "tile_fraction";
 const std::string_view kHorizontalName = "nMesh2d_face";
 const std::string_view kVerticalFullName = "full_levels";
 const std::string_view kVerticalHalfName = "half_levels";
+const std::string_view kVertFullNoSurfName = "full_levels_no_surf";
+const std::string_view kVertHalfWithTopName = "half_levels_with_top";
 
 const std::string_view kLfricMeshTerm = "Mesh2d";
 const std::string_view kLfricLonVarName = "Mesh2d_face_y";
@@ -190,6 +195,10 @@ const int kMPIRankOwner = 0;
 
 const int kVerticalFullSize = 71;
 const int kVerticalHalfSize = 70;
+const int kVertFullNoSurfSize = 70;
+const int kVertHalfWithTopSize = 71;
 
+const double kVerticalFullInc = 1;
+const double kVerticalHalfInc = 0.5;
 }  // namespace consts
 }  // namespace monio

--- a/src/monio/Constants.h
+++ b/src/monio/Constants.h
@@ -15,8 +15,6 @@
 
 namespace monio {
 namespace consts {
-
-using std::iota;
 /// Structs ////////////////////////////////////////////////////////////////////////////////////////
 
 /// \brief This struct is used for interfacing with the Monio singleton and its intended use-cases

--- a/src/monio/FileData.cc
+++ b/src/monio/FileData.cc
@@ -13,6 +13,7 @@ monio::FileData::FileData() :
   metadata_() {}
 
 void monio::FileData::clearData() {
+  metadata_.clear();  // Does not delete dimensions. Required for subsequent variables.
   data_.clear();
 }
 

--- a/src/monio/FileData.h
+++ b/src/monio/FileData.h
@@ -24,8 +24,8 @@ class FileData {
  public:
   FileData();
 
-  /// \brief Clears contents of Data. Used for memory-efficiency where written data can be dropped
-  ///        before writing subsequent variables.
+  /// \brief Clears contents of Data and all except dimensions in Metadata. Used for
+  ///        memory-efficiency where all but required data can be dropped.
   void clearData();
 
   Data& getData();

--- a/src/monio/Metadata.cc
+++ b/src/monio/Metadata.cc
@@ -128,7 +128,7 @@ bool monio::operator==(const monio::Metadata& lhs,
   return true;
 }
 
-bool monio::Metadata::isDimDefined(const std::string& dimName) {
+const bool monio::Metadata::isDimDefined(const std::string& dimName) const {
   oops::Log::debug() << "Metadata::isDimDefined()" << std::endl;
   auto it = dimensions_.find(dimName);
   if (it != dimensions_.end()) {
@@ -138,7 +138,7 @@ bool monio::Metadata::isDimDefined(const std::string& dimName) {
   }
 }
 
-int monio::Metadata::getDimension(const std::string& dimName) {
+const int monio::Metadata::getDimension(const std::string& dimName) const {
   oops::Log::debug() << "Metadata::getDimension()" << std::endl;
   if (isDimDefined(dimName) == true) {
     return dimensions_.at(dimName);

--- a/src/monio/Metadata.cc
+++ b/src/monio/Metadata.cc
@@ -10,7 +10,6 @@
 
 #include <algorithm>
 #include <iomanip>
-#include <numeric>
 #include <stdexcept>
 #include <string>
 #include <utility>

--- a/src/monio/Metadata.cc
+++ b/src/monio/Metadata.cc
@@ -325,7 +325,7 @@ const std::map<std::string, std::shared_ptr<monio::AttributeBase>>&
 int monio::Metadata::getNamingConvention() {
   int namingConvention = consts::eNotDefined;
   for (const auto& globalAttr : globalAttrs_) {
-    if (globalAttr.first == consts::kNamingConventionName) {
+    if (globalAttr.first == consts::kVariableConventionName) {
       std::shared_ptr<monio::AttributeString> dataFormatAttr =
             std::dynamic_pointer_cast<monio::AttributeString>(globalAttr.second);
       std::string dataFormatValue = dataFormatAttr->getValue();

--- a/src/monio/Metadata.cc
+++ b/src/monio/Metadata.cc
@@ -373,7 +373,7 @@ void monio::Metadata::deleteVariable(const std::string& varName) {
 
 void monio::Metadata::clear() {
   oops::Log::debug() << "Metadata::clear()" << std::endl;
-  dimensions_.clear();
+  // dimensions_.clear();  // Dimensions are required for correct writing of subsequent variables.
   variables_.clear();
   globalAttrs_.clear();
 }

--- a/src/monio/Metadata.cc
+++ b/src/monio/Metadata.cc
@@ -322,8 +322,8 @@ const std::map<std::string, std::shared_ptr<monio::AttributeBase>>&
   return globalAttrs_;
 }
 
-int monio::Metadata::getNamingConvention() {
-  int namingConvention = consts::eNotDefined;
+int monio::Metadata::getVariableConvention() {
+  int variableConvention = consts::eNotDefined;
   for (const auto& globalAttr : globalAttrs_) {
     if (globalAttr.first == consts::kVariableConventionName) {
       std::shared_ptr<monio::AttributeString> dataFormatAttr =
@@ -331,11 +331,11 @@ int monio::Metadata::getNamingConvention() {
       std::string dataFormatValue = dataFormatAttr->getValue();
       int pos = utils::findPosInVector(consts::kNamingConventions, dataFormatValue);
       if (pos != -1) {  // Condition preserves use of consts::eNotDefined == 2 when not found
-        namingConvention = pos;
+        variableConvention = pos;
       }
     }
   }
-  return namingConvention;
+  return variableConvention;
 }
 
 void monio::Metadata::removeAllButTheseVariables(

--- a/src/monio/Metadata.cc
+++ b/src/monio/Metadata.cc
@@ -10,6 +10,7 @@
 
 #include <algorithm>
 #include <iomanip>
+#include <numeric>
 #include <stdexcept>
 #include <string>
 #include <utility>

--- a/src/monio/Metadata.cc
+++ b/src/monio/Metadata.cc
@@ -323,7 +323,7 @@ const std::map<std::string, std::shared_ptr<monio::AttributeBase>>&
 }
 
 int monio::Metadata::getVariableConvention() {
-  int variableConvention = consts::eNotDefined;
+  int variableConvention = consts::eLfricConvention;  // Defaults to LFRic Convention
   for (const auto& globalAttr : globalAttrs_) {
     if (globalAttr.first == consts::kVariableConventionName) {
       std::shared_ptr<monio::AttributeString> dataFormatAttr =

--- a/src/monio/Metadata.h
+++ b/src/monio/Metadata.h
@@ -65,7 +65,7 @@ class Metadata {
 
   /// \brief Returns an number representing what naming convention an input file uses; JEDI or
   ///        LFRic, and if this is defined.
-  int getNamingConvention();
+  int getVariableConvention();
 
   void removeAllButTheseVariables(const std::vector<std::string>& varNames);
 

--- a/src/monio/Metadata.h
+++ b/src/monio/Metadata.h
@@ -26,8 +26,8 @@ class Metadata {
   friend bool operator==(const Metadata& lhs,
                          const Metadata& rhs);
 
-  bool isDimDefined(const std::string& dimName);
-  int getDimension(const std::string& dimName);
+  const bool isDimDefined(const std::string& dimName) const;
+  const int getDimension(const std::string& dimName) const;
 
   std::string getDimensionName(const int dimValue);
   const std::string getDimensionName(const int dimValue) const;

--- a/src/monio/Monio.cc
+++ b/src/monio/Monio.cc
@@ -179,10 +179,13 @@ void monio::Monio::writeIncrements(const atlas::FieldSet& localFieldSet,
         if (mpiCommunicator_.rank() == mpiRankOwner_) {
           // Configure write name
           std::string writeName;
+          std::string verticalConfigName;
           if (isLfricConvention == true) {
             writeName = fieldMetadata.lfricWriteName;
+            verticalConfigName = fieldMetadata.lfricVertConfig;
           } else if (isLfricConvention == false && fieldMetadata.jediName == globalField.name()) {
             writeName = fieldMetadata.jediName;
+            verticalConfigName = fieldMetadata.jediVertConfig;
           } else {
             Monio::get().closeFiles();
             utils::throwException("Monio::writeIncrements()> "
@@ -195,6 +198,7 @@ void monio::Monio::writeIncrements(const atlas::FieldSet& localFieldSet,
                                                  globalField,
                                                  fieldMetadata,
                                                  writeName,
+                                                 verticalConfigName,
                                                  isLfricConvention);
           writer_.writeMetadata(fileData.getMetadata());
           writer_.writeData(fileData);
@@ -238,10 +242,13 @@ void monio::Monio::writeState(const atlas::FieldSet& localFieldSet,
         if (mpiCommunicator_.rank() == mpiRankOwner_) {
           // Configure write name
           std::string writeName;
+          std::string verticalConfigName;
           if (isLfricConvention == true) {
             writeName = fieldMetadata.lfricReadName;
+            verticalConfigName = fieldMetadata.lfricVertConfig;
           } else if (isLfricConvention == false && fieldMetadata.jediName == globalField.name()) {
             writeName = fieldMetadata.jediName;
+            verticalConfigName = fieldMetadata.jediVertConfig;
           } else {
             Monio::get().closeFiles();
             utils::throwException("Monio::writeState()> Field metadata configuration error...");
@@ -253,6 +260,7 @@ void monio::Monio::writeState(const atlas::FieldSet& localFieldSet,
                                                  globalField,
                                                  fieldMetadata,
                                                  writeName,
+                                                 verticalConfigName,
                                                  isLfricConvention);
           writer_.writeMetadata(fileData.getMetadata());
           writer_.writeData(fileData);

--- a/src/monio/Monio.cc
+++ b/src/monio/Monio.cc
@@ -15,6 +15,7 @@
 #include "oops/util/Duration.h"
 #include "oops/util/Logger.h"
 
+#include "AttributeString.h"
 #include "Constants.h"
 #include "Utils.h"
 #include "UtilsAtlas.h"
@@ -447,13 +448,24 @@ void monio::Monio::addJediData(FileData& fileData) {
   metadata.addDimension(vertFullNoSurfName, consts::kVertFullNoSurfSize);
   metadata.addDimension(vertHalfWithTopName, consts::kVertHalfWithTopSize);
 
-  std::shared_ptr<monio::Variable> varFullNoSurf =
+  std::shared_ptr<monio::Variable> vertFullNoSurfVar =
         std::make_shared<Variable>(vertFullNoSurfName, consts::eDouble);
-  std::shared_ptr<monio::Variable> varHalfWithTop =
+  std::shared_ptr<monio::Variable> vertHalfWithTopVar =
         std::make_shared<Variable>(vertHalfWithTopName, consts::eDouble);
 
-  metadata.addVariable(vertFullNoSurfName, varFullNoSurf);
-  metadata.addVariable(vertHalfWithTopName, varHalfWithTop);
+  vertFullNoSurfVar->addDimension(vertFullNoSurfName, consts::kVertFullNoSurfSize);
+  vertHalfWithTopVar->addDimension(vertHalfWithTopName, consts::kVertHalfWithTopSize);
+
+  std::shared_ptr<AttributeBase> vertFullNoSurfAttr =
+        std::make_shared<AttributeString>("name", vertFullNoSurfName);
+  std::shared_ptr<AttributeBase> vertHalfWithTopAttr =
+        std::make_shared<AttributeString>("name", vertHalfWithTopName);
+
+  vertFullNoSurfVar->addAttribute(vertFullNoSurfAttr);
+  vertHalfWithTopVar->addAttribute(vertHalfWithTopAttr);
+
+  metadata.addVariable(vertFullNoSurfName, vertFullNoSurfVar);
+  metadata.addVariable(vertHalfWithTopName, vertHalfWithTopVar);
 
   std::vector<double> vertFullNoSurfValues(consts::kVertFullNoSurfSize);
   std::vector<double> vertHalfWithTopValues(consts::kVertHalfWithTopSize);

--- a/src/monio/Monio.cc
+++ b/src/monio/Monio.cc
@@ -77,7 +77,8 @@ void monio::Monio::readState(atlas::FieldSet& localFieldSet,
             // Read fields into memory
             reader_.readDatumAtTime(fileData, readName, dateTime,
                                     std::string(consts::kTimeDimName));
-            atlasReader_.populateFieldWithFileData(globalField, fileData, fieldMetadata, readName);
+            atlasReader_.populateFieldWithFileData(globalField, fileData, fieldMetadata, readName,
+                                                   namingConvention == consts::eLfricConvention);
           }
           auto& functionSpace = globalField.functionspace();
           functionSpace.scatter(globalField, localField);
@@ -131,7 +132,8 @@ void monio::Monio::readIncrements(atlas::FieldSet& localFieldSet,
                                   readName << "\"..." << std::endl;
             // Read fields into memory
             reader_.readFullDatum(fileData, readName);
-            atlasReader_.populateFieldWithFileData(globalField, fileData, fieldMetadata, readName);
+            atlasReader_.populateFieldWithFileData(globalField, fileData, fieldMetadata, readName,
+                                                   namingConvention == consts::eLfricConvention);
           }
           auto& functionSpace = globalField.functionspace();
           functionSpace.scatter(globalField, localField);

--- a/src/monio/Monio.cc
+++ b/src/monio/Monio.cc
@@ -84,9 +84,8 @@ void monio::Monio::readState(atlas::FieldSet& localFieldSet,
         }
         reader_.closeFile();
       } catch (netCDF::exceptions::NcException& exception) {
-        reader_.closeFile();
-        std::string exceptionMessage = exception.what();
         Monio::get().closeFiles();
+        std::string exceptionMessage = exception.what();
         utils::throwException("Monio::readState()> An exception has occurred: " + exceptionMessage);
       }
     } else {
@@ -139,10 +138,8 @@ void monio::Monio::readIncrements(atlas::FieldSet& localFieldSet,
         }
         reader_.closeFile();
       } catch (netCDF::exceptions::NcException& exception) {
-        oops::Log::info() << " exception.what()> " <<  exception.what() << std::endl;
-        reader_.closeFile();
-        std::string exceptionMessage = exception.what();
         Monio::get().closeFiles();
+        std::string exceptionMessage = exception.what();
         utils::throwException("Monio::readIncrements()> An exception has occurred: " +
                               exceptionMessage);
       }
@@ -202,9 +199,8 @@ void monio::Monio::writeIncrements(const atlas::FieldSet& localFieldSet,
       }
       writer_.closeFile();
     } catch (netCDF::exceptions::NcException& exception) {
-      writer_.closeFile();
-      std::string exceptionMessage = exception.what();
       Monio::get().closeFiles();
+      std::string exceptionMessage = exception.what();
       utils::throwException("Monio::writeIncrements()> An exception occurred: " + exceptionMessage);
     }
   } else {
@@ -258,9 +254,8 @@ void monio::Monio::writeState(const atlas::FieldSet& localFieldSet,
       }
       writer_.closeFile();
     } catch (netCDF::exceptions::NcException& exception) {
-      writer_.closeFile();
-      std::string exceptionMessage = exception.what();
       Monio::get().closeFiles();
+      std::string exceptionMessage = exception.what();
       utils::throwException("Monio::writeState()> An exception has occurred: " + exceptionMessage);
     }
   } else {
@@ -291,9 +286,8 @@ void monio::Monio::writeFieldSet(const atlas::FieldSet& localFieldSet,
       }
       writer_.closeFile();
     } catch (netCDF::exceptions::NcException& exception) {
-      writer_.closeFile();
-      std::string exceptionMessage = exception.what();
       Monio::get().closeFiles();
+      std::string exceptionMessage = exception.what();
       utils::throwException("Monio::writeFieldSet()> An exception occurred: " + exceptionMessage);
     }
   } else {

--- a/src/monio/Monio.cc
+++ b/src/monio/Monio.cc
@@ -68,7 +68,7 @@ void monio::Monio::readState(atlas::FieldSet& localFieldSet,
             FileData fileData = getFileData(grid.name());
             // Configure read name
             std::string readName = fieldMetadata.lfricReadName;
-            if (namingConvention == consts::eJediNaming) {
+            if (namingConvention == consts::eJediConvention) {
               readName = fieldMetadata.jediName;
             }
             oops::Log::debug() << "Monio::readState() processing data for> \"" <<
@@ -123,7 +123,7 @@ void monio::Monio::readIncrements(atlas::FieldSet& localFieldSet,
             FileData fileData = getFileData(grid.name());
             // Configure read name
             std::string readName = fieldMetadata.lfricReadName;
-            if (namingConvention == consts::eJediNaming) {
+            if (namingConvention == consts::eJediConvention) {
               readName = fieldMetadata.jediName;
             }
             oops::Log::debug() << "Monio::readIncrements() processing data for> \"" <<
@@ -306,7 +306,7 @@ int monio::Monio::initialiseFile(const atlas::Grid& grid,
                                  const std::string& filePath,
                                  bool doCreateDateTimes) {
   oops::Log::debug() << "Monio::initialiseFile()" << std::endl;
-  int namingConvention = consts::eNotDefined;
+  int variableConvention = consts::eNotDefined;
   if (mpiCommunicator_.rank() == mpiRankOwner_) {
     FileData& fileData = createFileData(grid.name(), filePath);
     reader_.openFile(filePath);
@@ -325,9 +325,9 @@ int monio::Monio::initialiseFile(const atlas::Grid& grid,
                       std::string(consts::kTimeVarName),
                       std::string(consts::kTimeOriginName));
     }
-    namingConvention = fileData.getMetadata().getNamingConvention();
+    variableConvention = fileData.getMetadata().getVariableConvention();
   }
-  return namingConvention;
+  return variableConvention;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/monio/Monio.cc
+++ b/src/monio/Monio.cc
@@ -323,7 +323,7 @@ int monio::Monio::initialiseFile(const atlas::Grid& grid,
                                  const std::string& filePath,
                                  bool doCreateDateTimes) {
   oops::Log::debug() << "Monio::initialiseFile()" << std::endl;
-  int variableConvention = consts::eNotDefined;
+  int variableConvention = consts::eLfricConvention;  // LFRic convention is default
   if (mpiCommunicator_.rank() == mpiRankOwner_) {
     FileData& fileData = createFileData(grid.name(), filePath);
     reader_.openFile(filePath);

--- a/src/monio/Monio.cc
+++ b/src/monio/Monio.cc
@@ -167,6 +167,7 @@ void monio::Monio::writeIncrements(const atlas::FieldSet& localFieldSet,
       auto& functionSpace = localFieldSet[0].functionspace();
       auto& grid = atlas::functionspace::NodeColumns(functionSpace).mesh().grid();
       FileData fileData = getFileData(grid.name());
+      cleanFileData(fileData);
       writer_.openFile(filePath);
       for (const auto& fieldMetadata : fieldMetadataVec) {
         auto& localField = localFieldSet[fieldMetadata.jediName];
@@ -223,6 +224,7 @@ void monio::Monio::writeState(const atlas::FieldSet& localFieldSet,
       auto& functionSpace = localFieldSet[0].functionspace();
       auto& grid = atlas::functionspace::NodeColumns(functionSpace).mesh().grid();
       FileData fileData = getFileData(grid.name());
+      cleanFileData(fileData);
       writer_.openFile(filePath);
       for (const auto& fieldMetadata : fieldMetadataVec) {
         auto& localField = localFieldSet[fieldMetadata.jediName];
@@ -325,7 +327,6 @@ int monio::Monio::initialiseFile(const atlas::Grid& grid,
                       std::string(consts::kTimeVarName),
                       std::string(consts::kTimeOriginName));
     }
-    cleanFileData(fileData);
     variableConvention = fileData.getMetadata().getVariableConvention();
   }
   return variableConvention;

--- a/src/monio/Monio.cc
+++ b/src/monio/Monio.cc
@@ -63,13 +63,13 @@ void monio::Monio::readState(atlas::FieldSet& localFieldSet,
             auto& grid = atlas::functionspace::NodeColumns(functionSpace).mesh().grid();
 
             // Initialise file
-            int namingConvention = initialiseFile(grid.name(), filePath, true);
+            int variableConvention = initialiseFile(grid.name(), filePath, true);
             // getFileData returns a copy of FileData (with required LFRic mesh data), so read data
             // is discarded when FileData goes out-of-scope for reading subsequent fields.
             FileData fileData = getFileData(grid.name());
             // Configure read name
             std::string readName = fieldMetadata.lfricReadName;
-            if (namingConvention == consts::eJediConvention) {
+            if (variableConvention == consts::eJediConvention) {
               readName = fieldMetadata.jediName;
             }
             oops::Log::debug() << "Monio::readState() processing data for> \"" <<
@@ -78,7 +78,7 @@ void monio::Monio::readState(atlas::FieldSet& localFieldSet,
             reader_.readDatumAtTime(fileData, readName, dateTime,
                                     std::string(consts::kTimeDimName));
             atlasReader_.populateFieldWithFileData(globalField, fileData, fieldMetadata, readName,
-                                                   namingConvention == consts::eLfricConvention);
+                                                   variableConvention == consts::eLfricConvention);
           }
           auto& functionSpace = globalField.functionspace();
           functionSpace.scatter(globalField, localField);
@@ -119,13 +119,13 @@ void monio::Monio::readIncrements(atlas::FieldSet& localFieldSet,
             auto& grid = atlas::functionspace::NodeColumns(functionSpace).mesh().grid();
 
             // Initialise file
-            int namingConvention = initialiseFile(grid.name(), filePath);
+            int variableConvention = initialiseFile(grid.name(), filePath);
             // getFileData returns a copy of FileData (with required LFRic mesh data), so read data
             // is discarded when FileData goes out-of-scope for reading subsequent fields.
             FileData fileData = getFileData(grid.name());
             // Configure read name
             std::string readName = fieldMetadata.lfricReadName;
-            if (namingConvention == consts::eJediConvention) {
+            if (variableConvention == consts::eJediConvention) {
               readName = fieldMetadata.jediName;
             }
             oops::Log::debug() << "Monio::readIncrements() processing data for> \"" <<
@@ -133,7 +133,7 @@ void monio::Monio::readIncrements(atlas::FieldSet& localFieldSet,
             // Read fields into memory
             reader_.readFullDatum(fileData, readName);
             atlasReader_.populateFieldWithFileData(globalField, fileData, fieldMetadata, readName,
-                                                   namingConvention == consts::eLfricConvention);
+                                                   variableConvention == consts::eLfricConvention);
           }
           auto& functionSpace = globalField.functionspace();
           functionSpace.scatter(globalField, localField);

--- a/src/monio/Monio.cc
+++ b/src/monio/Monio.cc
@@ -441,8 +441,19 @@ void monio::Monio::addJediData(FileData& fileData) {
   Metadata& metadata = fileData.getMetadata();
   Data& data = fileData.getData();
 
-  metadata.addDimension(std::string(consts::kVertFullNoSurfName), consts::kVertFullNoSurfSize);
-  metadata.addDimension(std::string(consts::kVertHalfWithTopName), consts::kVertHalfWithTopSize);
+  std::string vertFullNoSurfName = std::string(consts::kVertFullNoSurfName);
+  std::string vertHalfWithTopName = std::string(consts::kVertHalfWithTopName);
+
+  metadata.addDimension(vertFullNoSurfName, consts::kVertFullNoSurfSize);
+  metadata.addDimension(vertHalfWithTopName, consts::kVertHalfWithTopSize);
+
+  std::shared_ptr<monio::Variable> varFullNoSurf =
+        std::make_shared<Variable>(vertFullNoSurfName, consts::eDouble);
+  std::shared_ptr<monio::Variable> varHalfWithTop =
+        std::make_shared<Variable>(vertHalfWithTopName, consts::eDouble);
+
+  metadata.addVariable(vertFullNoSurfName, varFullNoSurf);
+  metadata.addVariable(vertHalfWithTopName, varHalfWithTop);
 
   std::vector<double> vertFullNoSurfValues(consts::kVertFullNoSurfSize);
   std::vector<double> vertHalfWithTopValues(consts::kVertHalfWithTopSize);
@@ -451,9 +462,9 @@ void monio::Monio::addJediData(FileData& fileData) {
   std::iota(vertHalfWithTopValues.begin(), vertHalfWithTopValues.end(), consts::kVerticalHalfInc);
 
   std::shared_ptr<DataContainerDouble> dataContainerFullNoSurf =
-        std::make_shared<DataContainerDouble>(std::string(consts::kVertFullNoSurfName));
+        std::make_shared<DataContainerDouble>(vertFullNoSurfName);
   std::shared_ptr<DataContainerDouble> dataContainerHalfWithTop =
-        std::make_shared<DataContainerDouble>(std::string(consts::kVertHalfWithTopName));
+        std::make_shared<DataContainerDouble>(vertHalfWithTopName);
 
   dataContainerFullNoSurf->setData(vertFullNoSurfValues);
   dataContainerHalfWithTop->setData(vertHalfWithTopValues);

--- a/src/monio/Monio.cc
+++ b/src/monio/Monio.cc
@@ -169,6 +169,9 @@ void monio::Monio::writeIncrements(const atlas::FieldSet& localFieldSet,
       auto& grid = atlas::functionspace::NodeColumns(functionSpace).mesh().grid();
       FileData fileData = getFileData(grid.name());
       cleanFileData(fileData);  // Remove metadata required for reading, but not for writing.
+      if (isLfricConvention == false) {
+        addJediData(fileData);
+      }
       writer_.openFile(filePath);
       for (const auto& fieldMetadata : fieldMetadataVec) {
         auto& localField = localFieldSet[fieldMetadata.jediName];
@@ -180,7 +183,6 @@ void monio::Monio::writeIncrements(const atlas::FieldSet& localFieldSet,
             writeName = fieldMetadata.lfricWriteName;
           } else if (isLfricConvention == false && fieldMetadata.jediName == globalField.name()) {
             writeName = fieldMetadata.jediName;
-            addJediData(fileData);
           } else {
             Monio::get().closeFiles();
             utils::throwException("Monio::writeIncrements()> "
@@ -196,7 +198,7 @@ void monio::Monio::writeIncrements(const atlas::FieldSet& localFieldSet,
                                                  isLfricConvention);
           writer_.writeMetadata(fileData.getMetadata());
           writer_.writeData(fileData);
-          fileData.clearData();  // Globalised field data no longer required
+          fileData.clearData();  // Written and globalised field data no longer required
         }
       }
       writer_.closeFile();
@@ -226,6 +228,9 @@ void monio::Monio::writeState(const atlas::FieldSet& localFieldSet,
       auto& grid = atlas::functionspace::NodeColumns(functionSpace).mesh().grid();
       FileData fileData = getFileData(grid.name());
       cleanFileData(fileData);  // Remove metadata required for reading, but not for writing.
+      if (isLfricConvention == false) {
+        addJediData(fileData);
+      }
       writer_.openFile(filePath);
       for (const auto& fieldMetadata : fieldMetadataVec) {
         auto& localField = localFieldSet[fieldMetadata.jediName];
@@ -237,7 +242,6 @@ void monio::Monio::writeState(const atlas::FieldSet& localFieldSet,
             writeName = fieldMetadata.lfricReadName;
           } else if (isLfricConvention == false && fieldMetadata.jediName == globalField.name()) {
             writeName = fieldMetadata.jediName;
-            addJediData(fileData);
           } else {
             Monio::get().closeFiles();
             utils::throwException("Monio::writeState()> Field metadata configuration error...");
@@ -252,7 +256,7 @@ void monio::Monio::writeState(const atlas::FieldSet& localFieldSet,
                                                  isLfricConvention);
           writer_.writeMetadata(fileData.getMetadata());
           writer_.writeData(fileData);
-          fileData.clearData();  // Globalised field data no longer required
+          fileData.clearData();  // Written and globalised field data no longer required
         }
       }
       writer_.closeFile();
@@ -284,7 +288,7 @@ void monio::Monio::writeFieldSet(const atlas::FieldSet& localFieldSet,
           atlasWriter_.populateFileDataWithField(fileData, globalField, globalField.name());
           writer_.writeMetadata(fileData.getMetadata());
           writer_.writeData(fileData);
-          fileData.clearData();  // Globalised field data no longer required
+          fileData.clearData();  // Written and globalised field data no longer required
         }
       }
       writer_.closeFile();

--- a/src/monio/Monio.cc
+++ b/src/monio/Monio.cc
@@ -167,7 +167,7 @@ void monio::Monio::writeIncrements(const atlas::FieldSet& localFieldSet,
       auto& functionSpace = localFieldSet[0].functionspace();
       auto& grid = atlas::functionspace::NodeColumns(functionSpace).mesh().grid();
       FileData fileData = getFileData(grid.name());
-      cleanFileData(fileData);
+      cleanFileData(fileData);  // Remove metadata required for reading, but not for writing.
       writer_.openFile(filePath);
       for (const auto& fieldMetadata : fieldMetadataVec) {
         auto& localField = localFieldSet[fieldMetadata.jediName];
@@ -224,7 +224,7 @@ void monio::Monio::writeState(const atlas::FieldSet& localFieldSet,
       auto& functionSpace = localFieldSet[0].functionspace();
       auto& grid = atlas::functionspace::NodeColumns(functionSpace).mesh().grid();
       FileData fileData = getFileData(grid.name());
-      cleanFileData(fileData);
+      cleanFileData(fileData);  // Remove metadata required for reading, but not for writing.
       writer_.openFile(filePath);
       for (const auto& fieldMetadata : fieldMetadataVec) {
         auto& localField = localFieldSet[fieldMetadata.jediName];
@@ -429,8 +429,7 @@ void monio::Monio::cleanFileData(FileData& fileData) {
     std::vector<std::string> dataContainerNames = fileData.getData().getDataContainerNames();
 
     for (const auto& metadataVarName : metadataVarNames) {
-      auto it = std::find(begin(dataContainerNames),
-                          end(dataContainerNames), metadataVarName);
+      auto it = std::find(begin(dataContainerNames), end(dataContainerNames), metadataVarName);
       if (it == std::end(dataContainerNames)) {
         fileData.getMetadata().deleteVariable(metadataVarName);
       }

--- a/src/monio/Monio.cc
+++ b/src/monio/Monio.cc
@@ -156,7 +156,7 @@ void monio::Monio::readIncrements(atlas::FieldSet& localFieldSet,
 void monio::Monio::writeIncrements(const atlas::FieldSet& localFieldSet,
                                    const std::vector<consts::FieldMetadata>& fieldMetadataVec,
                                    const std::string& filePath,
-                                   const bool isLfricNaming) {
+                                   const bool isLfricConvention) {
   oops::Log::debug() << "Monio::writeIncrements()" << std::endl;
   if (localFieldSet.size() == 0) {
     Monio::get().closeFiles();
@@ -175,9 +175,9 @@ void monio::Monio::writeIncrements(const atlas::FieldSet& localFieldSet,
         if (mpiCommunicator_.rank() == mpiRankOwner_) {
           // Configure write name
           std::string writeName;
-          if (isLfricNaming == true) {
+          if (isLfricConvention == true) {
             writeName = fieldMetadata.lfricWriteName;
-          } else if (isLfricNaming == false && fieldMetadata.jediName == globalField.name()) {
+          } else if (isLfricConvention == false && fieldMetadata.jediName == globalField.name()) {
             writeName = fieldMetadata.jediName;
           } else {
             Monio::get().closeFiles();
@@ -191,7 +191,7 @@ void monio::Monio::writeIncrements(const atlas::FieldSet& localFieldSet,
                                                  globalField,
                                                  fieldMetadata,
                                                  writeName,
-                                                 isLfricNaming);
+                                                 isLfricConvention);
           writer_.writeMetadata(fileData.getMetadata());
           writer_.writeData(fileData);
           fileData.clearData();  // Globalised field data no longer required
@@ -212,7 +212,7 @@ void monio::Monio::writeIncrements(const atlas::FieldSet& localFieldSet,
 void monio::Monio::writeState(const atlas::FieldSet& localFieldSet,
                               const std::vector<consts::FieldMetadata>& fieldMetadataVec,
                               const std::string& filePath,
-                              const bool isLfricNaming) {
+                              const bool isLfricConvention) {
   oops::Log::debug() << "Monio::writeState()" << std::endl;
   if (localFieldSet.size() == 0) {
     Monio::get().closeFiles();
@@ -231,9 +231,9 @@ void monio::Monio::writeState(const atlas::FieldSet& localFieldSet,
         if (mpiCommunicator_.rank() == mpiRankOwner_) {
           // Configure write name
           std::string writeName;
-          if (isLfricNaming == true) {
+          if (isLfricConvention == true) {
             writeName = fieldMetadata.lfricReadName;
-          } else if (isLfricNaming == false && fieldMetadata.jediName == globalField.name()) {
+          } else if (isLfricConvention == false && fieldMetadata.jediName == globalField.name()) {
             writeName = fieldMetadata.jediName;
           } else {
             Monio::get().closeFiles();
@@ -246,7 +246,7 @@ void monio::Monio::writeState(const atlas::FieldSet& localFieldSet,
                                                  globalField,
                                                  fieldMetadata,
                                                  writeName,
-                                                 isLfricNaming);
+                                                 isLfricConvention);
           writer_.writeMetadata(fileData.getMetadata());
           writer_.writeData(fileData);
           fileData.clearData();  // Globalised field data no longer required

--- a/src/monio/Monio.h
+++ b/src/monio/Monio.h
@@ -53,14 +53,14 @@ class Monio {
   void writeIncrements(const atlas::FieldSet& localFieldSet,
                        const std::vector<consts::FieldMetadata>& fieldMetadataVec,
                        const std::string& filePath,
-                       const bool isLfricNaming = true);
+                       const bool isLfricConvention = true);
 
   /// \brief Writes increment files. No time component but the variables can use JEDI or LFRic read
   ///        names. Intended debugging and testing only.
   void writeState(const atlas::FieldSet& localFieldSet,
                   const std::vector<consts::FieldMetadata>& fieldMetadataVec,
                   const std::string& filePath,
-                  const bool isLfricNaming = true);
+                  const bool isLfricConvention = true);
 
   /// \brief Writes an field set to file. Intended debugging and testing only.
   void writeFieldSet(const atlas::FieldSet& localFieldSet,

--- a/src/monio/Monio.h
+++ b/src/monio/Monio.h
@@ -99,7 +99,7 @@ class Monio {
   /// \brief Adds vertical meta/data for writing of JEDI-only increment files.
   void addJediData(FileData& fileData);
 
-  /// \brief Removes unnecessary meta/data from data read from file during initialisation.
+  /// \brief Removes unnecessary meta/data required for reading, but not for writing.
   void cleanFileData(FileData& fileData);
 
   /// \brief Necessary use of a standard pointer to a single instance of this class (as part of the

--- a/src/monio/Monio.h
+++ b/src/monio/Monio.h
@@ -85,6 +85,9 @@ class Monio {
   FileData& createFileData(const std::string& gridName,
                            const std::string& filePath);
 
+  /// \brief Returns a copy of the data read and produced during file initialisation.
+  FileData getFileData(const std::string& gridName);
+
   /// \brief Creates and stores a map between Atlas and LFRic horizontal ordering.
   void createLfricAtlasMap(FileData& fileData, const atlas::CubedSphereGrid& grid);
 
@@ -93,8 +96,8 @@ class Monio {
                        const std::string& timeVarName,
                        const std::string& timeOriginName);
 
-  /// \brief Returns a copy of the data read and produced during file initialisation.
-  FileData getFileData(const std::string& gridName);
+  /// \brief Adds vertical meta/data for writing of JEDI-only increment files.
+  void addJediData(FileData& fileData);
 
   /// \brief Removes unnecessary meta/data from data read from file during initialisation.
   void cleanFileData(FileData& fileData);

--- a/src/monio/Utils.cc
+++ b/src/monio/Utils.cc
@@ -84,8 +84,7 @@ template std::vector<std::string> extractKeys<std::string, std::shared_ptr<DataC
 template<typename T>
 int findPosInVector(std::vector<T> vector, T searchTerm) {
   int pos = -1;
-  typename std::vector<T>::iterator it;
-  it = std::find(vector.begin(), vector.end(), searchTerm);
+  typename std::vector<T>::iterator it = std::find(vector.begin(), vector.end(), searchTerm);
   if (it != vector.end()) {
     return std::distance(vector.begin(), it);
   }

--- a/test/monio/FieldSetWrite.h
+++ b/test/monio/FieldSetWrite.h
@@ -110,6 +110,9 @@ void initParams(atlas::FieldSet& fieldSet,
     fieldMetadata.jediName = utils::strNoWhiteSpace(stringVec[consts::eJediName]);
     fieldMetadata.lfricReadName = utils::strNoWhiteSpace(stringVec[consts::eLfricReadName]);
     fieldMetadata.lfricWriteName = utils::strNoWhiteSpace(stringVec[consts::eLfricWriteName]);
+    fieldMetadata.lfricVertConfig = utils::strNoWhiteSpace(stringVec[consts::eLfricVertConfig]);
+    fieldMetadata.jediVertConfig = utils::strNoWhiteSpace(stringVec[consts::eJediVertConfig]);
+    fieldMetadata.lfricWriteName = utils::strNoWhiteSpace(stringVec[consts::eLfricWriteName]);
     fieldMetadata.units = utils::strNoWhiteSpace(stringVec[consts::eUnits]);
     fieldMetadata.numberOfLevels =
                     std::stoi(utils::strNoWhiteSpace(stringVec[consts::eNumberOfLevels]));

--- a/test/monio/FieldSetWrite.h
+++ b/test/monio/FieldSetWrite.h
@@ -107,12 +107,11 @@ void initParams(atlas::FieldSet& fieldSet,
     std::vector<std::string> stringVec = utils::strToWords(fieldMetadata.getString(key), ',');
 
     consts::FieldMetadata fieldMetadata;
-    fieldMetadata.jediName = utils::strNoWhiteSpace(stringVec[consts::eJediName]);
     fieldMetadata.lfricReadName = utils::strNoWhiteSpace(stringVec[consts::eLfricReadName]);
     fieldMetadata.lfricWriteName = utils::strNoWhiteSpace(stringVec[consts::eLfricWriteName]);
+    fieldMetadata.jediName = utils::strNoWhiteSpace(stringVec[consts::eJediName]);
     fieldMetadata.lfricVertConfig = utils::strNoWhiteSpace(stringVec[consts::eLfricVertConfig]);
     fieldMetadata.jediVertConfig = utils::strNoWhiteSpace(stringVec[consts::eJediVertConfig]);
-    fieldMetadata.lfricWriteName = utils::strNoWhiteSpace(stringVec[consts::eLfricWriteName]);
     fieldMetadata.units = utils::strNoWhiteSpace(stringVec[consts::eUnits]);
     fieldMetadata.numberOfLevels =
                     std::stoi(utils::strNoWhiteSpace(stringVec[consts::eNumberOfLevels]));

--- a/test/monio/StateFull.h
+++ b/test/monio/StateFull.h
@@ -135,9 +135,11 @@ void initParams(atlas::FieldSet& firstFieldSet,
     std::vector<std::string> stringVec = utils::strToWords(fieldMetadata.getString(key), ',');
 
     consts::FieldMetadata fieldMetadata;
-    fieldMetadata.jediName = utils::strNoWhiteSpace(stringVec[consts::eJediName]);
     fieldMetadata.lfricReadName = utils::strNoWhiteSpace(stringVec[consts::eLfricReadName]);
     fieldMetadata.lfricWriteName = utils::strNoWhiteSpace(stringVec[consts::eLfricWriteName]);
+    fieldMetadata.jediName = utils::strNoWhiteSpace(stringVec[consts::eJediName]);
+    fieldMetadata.lfricVertConfig = utils::strNoWhiteSpace(stringVec[consts::eLfricVertConfig]);
+    fieldMetadata.jediVertConfig = utils::strNoWhiteSpace(stringVec[consts::eJediVertConfig]);
     fieldMetadata.units = utils::strNoWhiteSpace(stringVec[consts::eUnits]);
     fieldMetadata.numberOfLevels =
                     std::stoi(utils::strNoWhiteSpace(stringVec[consts::eNumberOfLevels]));

--- a/test/testinput/fieldset_write.yaml
+++ b/test/testinput/fieldset_write.yaml
@@ -1,10 +1,11 @@
 parameters:
   fieldMetadata:
-    exner:                    exner,                    exner_levels_minus_one, exner_levels_minus_one, 1,    70, false
-    grid_surface_temperature: grid_surface_temperature, skin_temperature,       skin_temperature,       K,    1,  false
-    theta:                    theta,                    potential_temperature,  potential_temperature,  K,    71, true
-    u_in_w3:                  u_in_w3,                  eastward_wind,          eastward_wind,          ms-1, 70, false
-    v_in_w3:                  v_in_w3,                  northward_wind,         northward_wind,         ms-1, 70, false
+    exner:                    exner,                    exner_levels_minus_one, exner_levels_minus_one, half_levels, half_levels,         1,    70, false
+    grid_surface_temperature: grid_surface_temperature, skin_temperature,       skin_temperature,       Mesh2d_face, Mesh2d_face,         K,    1,  false
+    pressure_in_wth:          pressure_in_wth,          pressure_in_wth,        air_presssure,          full_levels, full_levels_no_surf, Pa,   71, false
+    theta:                    theta,                    potential_temperature,  potential_temperature,  full_levels, full_levels_no_surf, K,    71, true
+    u_in_w3:                  u_in_w3,                  eastward_wind,          eastward_wind,          half_levels, half_levels,         ms-1, 70, false
+    v_in_w3:                  v_in_w3,                  northward_wind,         northward_wind,         half_levels, half_levels,         ms-1, 70, false
   gridName: CS-LFR-48
   partitionerType: cubedsphere
   meshType: cubedsphere_dual

--- a/test/testinput/state_full.yaml
+++ b/test/testinput/state_full.yaml
@@ -1,11 +1,11 @@
 parameters:
   fieldMetadata:
-    exner:                    exner,                    exner,                    exner_levels_minus_one, 1,    70, false
-    grid_surface_temperature: grid_surface_temperature, grid_surface_temperature, skin_temperature,       K,    1,  false
-    pressure_in_wth:          pressure_in_wth,          pressure_in_wth,          air_presssure,          Pa,   71, false
-    theta:                    theta,                    theta,                    potential_temperature,  K,    71, true
-    u_in_w3:                  u_in_w3,                  u_in_w3,                  eastward_wind,          ms-1, 70, false
-    v_in_w3:                  v_in_w3,                  v_in_w3,                  northward_wind,         ms-1, 70, false
+    exner:                    exner,                    exner_levels_minus_one, exner_levels_minus_one, half_levels, half_levels,         1,    70, false
+    grid_surface_temperature: grid_surface_temperature, skin_temperature,       skin_temperature,       Mesh2d_face, Mesh2d_face,         K,    1,  false
+    pressure_in_wth:          pressure_in_wth,          pressure_in_wth,        air_presssure,          full_levels, full_levels_no_surf, Pa,   71, false
+    theta:                    theta,                    potential_temperature,  potential_temperature,  full_levels, full_levels_no_surf, K,    71, true
+    u_in_w3:                  u_in_w3,                  eastward_wind,          eastward_wind,          half_levels, half_levels,         ms-1, 70, false
+    v_in_w3:                  v_in_w3,                  northward_wind,         northward_wind,         half_levels, half_levels,         ms-1, 70, false
   gridName: CS-LFR-224
   partitionerType: cubedsphere
   meshType: cubedsphere_dual


### PR DESCRIPTION
Addition of vertical meta/data to NetCDF files for outputs that adopt JEDI variable conventions.

This PR will be part of a coordinated merge with:
- LFRic-Lite https://github.com/JCSDA-internal/lfric-lite-jedi/pull/376

Test outputs (LFRic-Lite, LFRic-JEDI, & MONIO): http://fcm1/cylc-review/taskjobs/punderwo/?suite=levels_metadata_01