### PR TITLE
Minor modifications to Monio::readState for HofX

### DIFF
--- a/src/monio/Monio.cc
+++ b/src/monio/Monio.cc
@@ -78,7 +78,7 @@ void monio::Monio::readState(atlas::FieldSet& localFieldSet,
               reader_.readDatumAtTime(fileData, readName, dateTime,
                                       std::string(consts::kTimeDimName));
               atlasReader_.populateFieldWithFileData(globalField, fileData, fieldMetadata, readName,
-                                                     variableConvention == consts::eLfricConvention);
+                                                    variableConvention == consts::eLfricConvention);
             } else {
               oops::Log::info() << "Monio::readState()> Variable \"" + fieldMetadata.jediName +
                                    "\" not defined in LFRic. Skipping read..." << std::endl;

--- a/src/monio/Monio.cc
+++ b/src/monio/Monio.cc
@@ -61,7 +61,6 @@ void monio::Monio::readState(atlas::FieldSet& localFieldSet,
           if (mpiCommunicator_.rank() == mpiRankOwner_) {
             auto& functionSpace = globalField.functionspace();
             auto& grid = atlas::functionspace::NodeColumns(functionSpace).mesh().grid();
-
             // Initialise file
             int variableConvention = initialiseFile(grid.name(), filePath, true);
             // getFileData returns a copy of FileData (with required LFRic mesh data), so read data
@@ -72,13 +71,18 @@ void monio::Monio::readState(atlas::FieldSet& localFieldSet,
             if (variableConvention == consts::eJediConvention) {
               readName = fieldMetadata.jediName;
             }
-            oops::Log::debug() << "Monio::readState() processing data for> \"" <<
-                                  readName << "\"..." << std::endl;
-            // Read fields into memory
-            reader_.readDatumAtTime(fileData, readName, dateTime,
-                                    std::string(consts::kTimeDimName));
-            atlasReader_.populateFieldWithFileData(globalField, fileData, fieldMetadata, readName,
-                                                   variableConvention == consts::eLfricConvention);
+            if (utils::findInVector(consts::kMissingVariableNames, readName) == false) {
+              oops::Log::debug() << "Monio::readState() processing data for> \"" <<
+                                    readName << "\"..." << std::endl;
+              // Read fields into memory
+              reader_.readDatumAtTime(fileData, readName, dateTime,
+                                      std::string(consts::kTimeDimName));
+              atlasReader_.populateFieldWithFileData(globalField, fileData, fieldMetadata, readName,
+                                                     variableConvention == consts::eLfricConvention);
+            } else {
+              oops::Log::info() << "Monio::readState()> Variable \"" + fieldMetadata.jediName +
+                                   "\" not defined in LFRic. Skipping read..." << std::endl;
+            }
           }
           auto& functionSpace = globalField.functionspace();
           functionSpace.scatter(globalField, localField);

--- a/src/monio/Utils.cc
+++ b/src/monio/Utils.cc
@@ -54,7 +54,7 @@ bool strToBool(std::string input) {
              (cleanStr.size() == 5 && cleanStr == "false")) {
     return false;
   } else {
-    throw std::invalid_argument("ERROR> Input value of \"" + input + "\" is not valid.");
+    throw std::invalid_argument("utils::strToBool> Input value of \"" + input + "\" is not valid.");
   }
 }
 

--- a/src/monio/Utils.cc
+++ b/src/monio/Utils.cc
@@ -11,6 +11,7 @@
 #include <algorithm>
 #include <fstream>
 #include <memory>
+#include <stdio.h>
 
 #include "AttributeBase.h"
 #include "DataContainerBase.h"
@@ -56,6 +57,22 @@ bool strToBool(std::string input) {
   } else {
     throw std::invalid_argument("utils::strToBool> Input value of \"" + input + "\" is not valid.");
   }
+}
+
+std::string exec(const std::string& cmd) {
+  std::array<char, 128> buffer;
+  std::string result;
+
+  std::string extCmd = "sh -c '" + cmd + "' 2>&1";
+
+  std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(extCmd.c_str(), "r"), pclose);
+  if (!pipe) {
+    throw std::runtime_error("popen() failed!");
+  }
+  while (fgets(buffer.data(), buffer.size(), pipe.get()) != nullptr) {
+    result += buffer.data();
+  }
+  return result;
 }
 
 bool fileExists(std::string path) {

--- a/src/monio/Utils.cc
+++ b/src/monio/Utils.cc
@@ -64,9 +64,7 @@ bool strToBool(std::string input) {
 std::string exec(const std::string& cmd) {
   std::array<char, 128> buffer;
   std::string result;
-
   std::string extCmd = "sh -c '" + cmd + "' 2>&1";
-
   std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(extCmd.c_str(), "r"), pclose);
   if (!pipe) {
     throw std::runtime_error("popen() failed!");

--- a/src/monio/Utils.cc
+++ b/src/monio/Utils.cc
@@ -8,10 +8,11 @@
 ******************************************************************************/
 #include "Utils.h"
 
+#include <stdio.h>
+
 #include <algorithm>
 #include <fstream>
 #include <memory>
-#include <stdio.h>
 
 #include "AttributeBase.h"
 #include "DataContainerBase.h"

--- a/src/monio/Utils.cc
+++ b/src/monio/Utils.cc
@@ -11,6 +11,7 @@
 #include <stdio.h>
 
 #include <algorithm>
+#include <array>
 #include <fstream>
 #include <memory>
 

--- a/src/monio/Utils.h
+++ b/src/monio/Utils.h
@@ -27,6 +27,8 @@ namespace utils {
   bool strToBool(std::string input);
   bool fileExists(std::string path);
 
+  std::string exec(const std::string& cmd);
+
   template<typename T1, typename T2>
   std::vector<T1> extractKeys(std::map<T1, T2> const& inputMap);
 


### PR DESCRIPTION
In HofX tests there is a current need to pre-allocate fields that do not exist in the model, but which are populated as part of a variable transformation process. This use-case had not previously been tested in this version of MONIO and has indicated the need to check for fields that are not available in the state file. This PR introduces that check, and generates a warning message if reading is skipped.

Test outputs in MONIO, and with LFRic-Lite and LFRic-JEDI (on feature/hofx_io_compare): http://fcm1/cylc-review/taskjobs/punderwo/?suite=hofx_io_comapare_02