### PR TITLE
Fixes for building outside of a bundle.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 
 cmake_minimum_required(VERSION 3.12)
 
-project(monio VERSION 0.0.1 LANGUAGES CXX)
+project(monio VERSION 0.0.1 LANGUAGES Fortran CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake;${CMAKE_MODULE_PATH})
 set(CMAKE_DIRECTORY_LABELS ${PROJECT_NAME})
@@ -27,6 +27,7 @@ ecbuild_declare_project()
 set(MONIO_LINKER_LANGUAGE CXX)
 
 ## Dependencies
+find_package( jedicmake QUIET )  # Prefer find modules from jedi-cmake
 find_package(MPI REQUIRED COMPONENTS CXX)
 find_package(HDF5 REQUIRED COMPONENTS)
 find_package(NetCDF COMPONENTS CXX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ ecbuild_declare_project()
 set(MONIO_LINKER_LANGUAGE CXX)
 
 ## Dependencies
-find_package( jedicmake QUIET )  # Prefer find modules from jedi-cmake
+find_package(jedicmake QUIET)  # Prefer find modules from jedi-cmake
 find_package(MPI REQUIRED COMPONENTS CXX)
 find_package(HDF5 REQUIRED COMPONENTS)
 find_package(NetCDF COMPONENTS CXX)


### PR DESCRIPTION
Fixes #30.  There are two issues:

1. The failure in #30 is addressed by adding Fortran to the list of LANGUAGES in the project call.
2. The next failure was this:

```
Found CMake version 3.22.2
CMake Error at /home/h01/frwd/cylc-run/mi-be984/share/installs/ecbuild/share/ecbuild/cmake/ecbuild_add_library.cmake:302 (add_library):
  Target "monio" links to target "NetCDF::NetCDF_CXX" but the target was not
  found.  Perhaps a find_package() call is missing for an IMPORTED target, or
  an ALIAS target is missing?
Call Stack (most recent call first):
  /home/h01/frwd/cylc-run/mi-be984/share/installs/ecbuild/share/ecbuild/cmake/ecbuild_add_library.cmake:657 (ecbuild_add_library_impl)
  src/CMakeLists.txt:59 (ecbuild_add_library)
```

This was fixed by importing jedi-cmake to use its NetCDF find instead of the standard one; this enables the NetCDF CXX stuff to be found correctly.

Both of these failures are circumvented in mo-bundle due to previous imports and whatnot.