### PR TITLE
Use trace for function name prints

### DIFF
--- a/src/monio/AtlasReader.cc
+++ b/src/monio/AtlasReader.cc
@@ -17,7 +17,7 @@
 monio::AtlasReader::AtlasReader(const eckit::mpi::Comm& mpiCommunicator, const int mpiRankOwner):
     mpiCommunicator_(mpiCommunicator),
     mpiRankOwner_(mpiRankOwner) {
-  oops::Log::debug() << "AtlasReader::AtlasReader()" << std::endl;
+  oops::Log::trace() << "AtlasReader::AtlasReader()" << std::endl;
 }
 
 void monio::AtlasReader::populateFieldWithFileData(atlas::Field& field,
@@ -25,7 +25,7 @@ void monio::AtlasReader::populateFieldWithFileData(atlas::Field& field,
                                              const consts::FieldMetadata& fieldMetadata,
                                              const std::string& readName,
                                              const bool isLfricConvention) {
-  oops::Log::debug() << "AtlasReader::populateFieldWithFileData()" << std::endl;
+  oops::Log::trace() << "AtlasReader::populateFieldWithFileData()" << std::endl;
   atlas::Field readField = getReadField(field, fieldMetadata.noFirstLevel);
   populateFieldWithDataContainer(readField,
                                  fileData.getData().getContainer(readName),
@@ -39,7 +39,7 @@ void monio::AtlasReader::populateFieldWithDataContainer(atlas::Field& field,
                                       const std::vector<size_t>& lfricToAtlasMap,
                                       const bool noFirstLevel,
                                       const bool isLfricConvention) {
-  oops::Log::debug() << "AtlasReader::populateFieldWithDataContainer()" << std::endl;
+  oops::Log::trace() << "AtlasReader::populateFieldWithDataContainer()" << std::endl;
   if (mpiCommunicator_.rank() == mpiRankOwner_) {
     int dataType = dataContainer.get()->getType();
     switch (dataType) {
@@ -75,7 +75,7 @@ void monio::AtlasReader::populateFieldWithDataContainer(atlas::Field& field,
 
 void monio::AtlasReader::populateFieldWithDataContainer(atlas::Field& field,
                                       const std::shared_ptr<DataContainerBase>& dataContainer) {
-  oops::Log::debug() << "AtlasReader::populateFieldWithDataContainer()" << std::endl;
+  oops::Log::trace() << "AtlasReader::populateFieldWithDataContainer()" << std::endl;
   if (mpiCommunicator_.rank() == mpiRankOwner_) {
     int dataType = dataContainer.get()->getType();
     switch (dataType) {
@@ -112,7 +112,7 @@ void monio::AtlasReader::populateField(atlas::Field& field,
                                  const std::vector<size_t>& lfricToAtlasMap,
                                  const bool noFirstLevel,
                                  const bool isLfricConvention) {
-  oops::Log::debug() << "AtlasReader::populateField()" << std::endl;
+  oops::Log::trace() << "AtlasReader::populateField()" << std::endl;
   auto fieldView = atlas::array::make_view<T, 2>(field);
   // Field with noFirstLevel == true should have been adjusted to have 70 levels.
   atlas::idx_t numLevels = field.shape(consts::eVertical);
@@ -175,7 +175,7 @@ template void monio::AtlasReader::populateField<int>(atlas::Field& field,
 template<typename T>
 void monio::AtlasReader::populateField(atlas::Field& field,
                                        const std::vector<T>& dataVec) {
-  oops::Log::debug() << "AtlasReader::populateField()" << std::endl;
+  oops::Log::trace() << "AtlasReader::populateField()" << std::endl;
 
   std::vector<atlas::idx_t> fieldShape = field.shape();
   if (field.metadata().get<bool>("global") == false) {

--- a/src/monio/AtlasWriter.cc
+++ b/src/monio/AtlasWriter.cc
@@ -25,7 +25,7 @@
 monio::AtlasWriter::AtlasWriter(const eckit::mpi::Comm& mpiCommunicator, const int mpiRankOwner):
     mpiCommunicator_(mpiCommunicator),
     mpiRankOwner_(mpiRankOwner) {
-  oops::Log::debug() << "AtlasWriter::AtlasWriter()" << std::endl;
+  oops::Log::trace() << "AtlasWriter::AtlasWriter()" << std::endl;
 }
 
 void monio::AtlasWriter::populateFileDataWithField(FileData& fileData,
@@ -34,7 +34,7 @@ void monio::AtlasWriter::populateFileDataWithField(FileData& fileData,
                                              const std::string& writeName,
                                              const std::string& vertConfigName,
                                              const bool isLfricConvention) {
-  oops::Log::debug() << "AtlasWriter::populateFileDataWithField()" << std::endl;
+  oops::Log::trace() << "AtlasWriter::populateFileDataWithField()" << std::endl;
   if (mpiCommunicator_.rank() == mpiRankOwner_) {
     std::vector<size_t>& lfricAtlasMap = fileData.getLfricAtlasMap();
     // Create dimensions
@@ -54,7 +54,7 @@ void monio::AtlasWriter::populateFileDataWithField(FileData& fileData,
 void monio::AtlasWriter::populateFileDataWithField(FileData& fileData,
                                              const atlas::Field& field,
                                              const std::string& writeName) {
-  oops::Log::debug() << "AtlasWriter::populateFileDataWithField()" << std::endl;
+  oops::Log::trace() << "AtlasWriter::populateFileDataWithField()" << std::endl;
   if (mpiCommunicator_.rank() == mpiRankOwner_) {
     Metadata& metadata = fileData.getMetadata();
     Data& data = fileData.getData();
@@ -102,7 +102,7 @@ void monio::AtlasWriter::populateMetadataWithField(Metadata& metadata,
                                              const consts::FieldMetadata& fieldMetadata,
                                              const std::string& varName,
                                              const std::string& vertConfigName) {
-  oops::Log::debug() << "AtlasWriter::populateMetadataWithField()" << std::endl;
+  oops::Log::trace() << "AtlasWriter::populateMetadataWithField()" << std::endl;
   int type = utilsatlas::atlasTypeToMonioEnum(field.datatype());
   std::shared_ptr<monio::Variable> var = std::make_shared<Variable>(varName, type);
   // Variable dimensions
@@ -134,7 +134,7 @@ void monio::AtlasWriter::populateMetadataWithField(Metadata& metadata,
 void monio::AtlasWriter::populateMetadataWithField(Metadata& metadata,
                                              const atlas::Field& field,
                                              const std::string& varName) {
-  oops::Log::debug() << "AtlasWriter::populateMetadataWithField()" << std::endl;
+  oops::Log::trace() << "AtlasWriter::populateMetadataWithField()" << std::endl;
   int type = utilsatlas::atlasTypeToMonioEnum(field.datatype());
   std::shared_ptr<monio::Variable> var = std::make_shared<Variable>(varName, type);
   // Variable dimensions
@@ -146,7 +146,7 @@ void monio::AtlasWriter::populateDataWithField(Data& data,
                                          const atlas::Field& field,
                                          const std::vector<size_t>& lfricToAtlasMap,
                                          const std::string& fieldName) {
-  oops::Log::debug() << "AtlasWriter::populateDataWithField()" << std::endl;
+  oops::Log::trace() << "AtlasWriter::populateDataWithField()" << std::endl;
   std::shared_ptr<DataContainerBase> dataContainer = nullptr;
   populateDataContainerWithField(dataContainer, field, lfricToAtlasMap, fieldName);
   data.addContainer(dataContainer);
@@ -155,7 +155,7 @@ void monio::AtlasWriter::populateDataWithField(Data& data,
 void monio::AtlasWriter::populateDataWithField(Data& data,
                                          const atlas::Field& field,
                                          const std::vector<atlas::idx_t>& dimensions) {
-  oops::Log::debug() << "AtlasWriter::populateDataWithField()" << std::endl;
+  oops::Log::trace() << "AtlasWriter::populateDataWithField()" << std::endl;
   std::shared_ptr<DataContainerBase> dataContainer = nullptr;
   populateDataContainerWithField(dataContainer, field, dimensions);
   data.addContainer(dataContainer);
@@ -166,7 +166,7 @@ void monio::AtlasWriter::populateDataContainerWithField(
                                const atlas::Field& field,
                                const std::vector<size_t>& lfricToAtlasMap,
                                const std::string& fieldName) {
-  oops::Log::debug() << "AtlasWriter::populateDataContainerWithField()" << std::endl;
+  oops::Log::trace() << "AtlasWriter::populateDataContainerWithField()" << std::endl;
   if (mpiCommunicator_.rank() == mpiRankOwner_) {
     atlas::array::DataType atlasType = field.datatype();
     atlas::idx_t fieldSize = utilsatlas::getGlobalDataSize(field);
@@ -217,7 +217,7 @@ void monio::AtlasWriter::populateDataContainerWithField(
                                      std::shared_ptr<monio::DataContainerBase>& dataContainer,
                                const atlas::Field& field,
                                const std::vector<atlas::idx_t>& dimensions) {
-  oops::Log::debug() << "AtlasWriter::populateDataContainerWithField()" << std::endl;
+  oops::Log::trace() << "AtlasWriter::populateDataContainerWithField()" << std::endl;
   if (mpiCommunicator_.rank() == mpiRankOwner_) {
     std::string fieldName = field.name();
     atlas::array::DataType atlasType = field.datatype();
@@ -269,7 +269,7 @@ template<typename T>
 void monio::AtlasWriter::populateDataVec(std::vector<T>& dataVec,
                                    const atlas::Field& field,
                                    const std::vector<size_t>& lfricToAtlasMap) {
-  oops::Log::debug() << "AtlasWriter::populateDataVec() " << field.name() << std::endl;
+  oops::Log::trace() << "AtlasWriter::populateDataVec() " << field.name() << std::endl;
   atlas::idx_t numLevels = field.shape(consts::eVertical);
   if ((lfricToAtlasMap.size() * numLevels) != dataVec.size()) {
     Monio::get().closeFiles();
@@ -299,7 +299,7 @@ template<typename T>
 void monio::AtlasWriter::populateDataVec(std::vector<T>& dataVec,
                                    const atlas::Field& field,
                                    const std::vector<atlas::idx_t>& dimensions) {
-  oops::Log::debug() << "AtlasWriter::populateDataVec()" << std::endl;
+  oops::Log::trace() << "AtlasWriter::populateDataVec()" << std::endl;
   auto fieldView = atlas::array::make_view<T, 2>(field);
   for (atlas::idx_t i = 0; i < dimensions[consts::eHorizontal]; ++i) {
     for (atlas::idx_t j = 0; j < dimensions[consts::eVertical]; ++j) {
@@ -322,7 +322,7 @@ template void monio::AtlasWriter::populateDataVec<int>(std::vector<int>& dataVec
 atlas::Field monio::AtlasWriter::getWriteField(atlas::Field& field,
                                          const std::string& writeName,
                                          const bool noFirstLevel) {
-  oops::Log::debug() << "AtlasWriter::getWriteField()" << std::endl;
+  oops::Log::trace() << "AtlasWriter::getWriteField()" << std::endl;
   atlas::FunctionSpace functionSpace = field.functionspace();
   atlas::array::DataType atlasType = field.datatype();
   if (atlasType != atlasType.KIND_REAL64 &&
@@ -368,7 +368,7 @@ template<typename T>
 atlas::Field monio::AtlasWriter::copySurfaceLevel(const atlas::Field& inputField,
                               const atlas::FunctionSpace& functionSpace,
                               const atlas::util::Config& atlasOptions) {
-  oops::Log::debug() << "AtlasWriter::copySurfaceLevel()" << std::endl;
+  oops::Log::trace() << "AtlasWriter::copySurfaceLevel()" << std::endl;
   atlas::Field copiedField = functionSpace.createField<T>(atlasOptions);
   auto copiedFieldView = atlas::array::make_view<T, 2>(copiedField);
   auto inputFieldView = atlas::array::make_view<T, 2>(inputField);

--- a/src/monio/Data.cc
+++ b/src/monio/Data.cc
@@ -35,7 +35,7 @@ template<typename T> bool compareData(std::vector<T>& lhsVec, std::vector<T>& rh
 }  // anonymous namespace
 
 monio::Data::Data() {
-  oops::Log::debug() << "Data::Data()" << std::endl;
+  oops::Log::trace() << "Data::Data()" << std::endl;
 }
 
 bool monio::operator==(const monio::Data& lhs, const monio::Data& rhs) {
@@ -100,7 +100,7 @@ bool monio::operator==(const monio::Data& lhs, const monio::Data& rhs) {
 }
 
 void monio::Data::addContainer(std::shared_ptr<DataContainerBase> container) {
-  oops::Log::debug() << "Data::addContainer()" << std::endl;
+  oops::Log::trace() << "Data::addContainer()" << std::endl;
   const std::string& name = container->getName();
   auto it = dataContainers_.find(name);
   if (it == dataContainers_.end()) {
@@ -109,7 +109,7 @@ void monio::Data::addContainer(std::shared_ptr<DataContainerBase> container) {
 }
 
 void monio::Data::deleteContainer(const std::string& name) {
-  oops::Log::debug() << "Data::deleteContainer()" << std::endl;
+  oops::Log::trace() << "Data::deleteContainer()" << std::endl;
   auto it = dataContainers_.find(name);
   if (it != dataContainers_.end()) {
     dataContainers_.erase(name);
@@ -117,7 +117,7 @@ void monio::Data::deleteContainer(const std::string& name) {
 }
 
 void monio::Data::removeAllButTheseContainers(const std::vector<std::string>& names) {
-  oops::Log::debug() << "Data::removeAllButTheseContainers()" << std::endl;
+  oops::Log::trace() << "Data::removeAllButTheseContainers()" << std::endl;
   std::vector<std::string> containerKeys = utils::extractKeys(dataContainers_);
   for (const std::string& containerKey : containerKeys) {
     if (utils::findInVector(names, containerKey) == false) {
@@ -127,7 +127,7 @@ void monio::Data::removeAllButTheseContainers(const std::vector<std::string>& na
 }
 
 bool monio::Data::isContainerPresent(const std::string& name) const {
-  oops::Log::debug() << "Data::isContainerPresent()" << std::endl;
+  oops::Log::trace() << "Data::isContainerPresent()" << std::endl;
   auto it = dataContainers_.find(name);
   if (it != dataContainers_.end()) {
     return true;
@@ -138,7 +138,7 @@ bool monio::Data::isContainerPresent(const std::string& name) const {
 
 std::shared_ptr<monio::DataContainerBase>
                 monio::Data::getContainer(const std::string& name) const {
-  oops::Log::debug() << "Data::getContainer()" << std::endl;
+  oops::Log::trace() << "Data::getContainer()" << std::endl;
   auto it = dataContainers_.find(name);
   if (it != dataContainers_.end()) {
     return it->second;
@@ -150,22 +150,22 @@ std::shared_ptr<monio::DataContainerBase>
 
 std::map<std::string, std::shared_ptr<monio::DataContainerBase>>&
                                       monio::Data::getContainers() {
-  oops::Log::debug() << "Data::getContainers()" << std::endl;
+  oops::Log::trace() << "Data::getContainers()" << std::endl;
   return dataContainers_;
 }
 
 const std::map<std::string, std::shared_ptr<monio::DataContainerBase>>&
                                             monio::Data::getContainers() const {
-  oops::Log::debug() << "Data::getContainers()" << std::endl;
+  oops::Log::trace() << "Data::getContainers()" << std::endl;
   return dataContainers_;
 }
 
 std::vector<std::string> monio::Data::getDataContainerNames() const {
-  oops::Log::debug() << "Data::getDataContainerNames()" << std::endl;
+  oops::Log::trace() << "Data::getDataContainerNames()" << std::endl;
   return utils::extractKeys(dataContainers_);
 }
 
 void monio::Data::clear() {
-  oops::Log::debug() << "Data::clear()" << std::endl;
+  oops::Log::trace() << "Data::clear()" << std::endl;
   dataContainers_.clear();
 }

--- a/src/monio/File.cc
+++ b/src/monio/File.cc
@@ -30,7 +30,7 @@ monio::File::File(const std::string& filePath,
                   filePath_(filePath),
                   fileMode_(fileMode) {
   try {
-    oops::Log::debug() << "File::File(): filePath_> " <<  filePath_  <<
+    oops::Log::trace() << "File::File(): filePath_> " <<  filePath_  <<
                          ", fileMode_> " << fileMode_ << std::endl;
     dataFile_ = std::make_unique<netCDF::NcFile>(filePath_, fileMode_);
   } catch (netCDF::exceptions::NcException& exception) {
@@ -47,7 +47,7 @@ monio::File::~File() {
 }
 
 void monio::File::close() {
-  oops::Log::debug() << "File::close() ";
+  oops::Log::trace() << "File::close() ";
   if (fileMode_ == netCDF::NcFile::read) {
     oops::Log::debug() << "read" << std::endl;
   } else if (fileMode_ == netCDF::NcFile::write) {
@@ -59,7 +59,7 @@ void monio::File::close() {
 // Reading functions ///////////////////////////////////////////////////////////////////////////////
 
 void monio::File::readMetadata(Metadata& metadata) {
-  oops::Log::debug() << "File::readMetadata()" << std::endl;
+  oops::Log::trace() << "File::readMetadata()" << std::endl;
   if (fileMode_ == netCDF::NcFile::read) {
     readDimensions(metadata);  // Should be called before readVariables()
     readVariables(metadata);
@@ -73,7 +73,7 @@ void monio::File::readMetadata(Metadata& metadata) {
 
 void monio::File::readMetadata(Metadata& metadata,
                                const std::vector<std::string>& varNames) {
-  oops::Log::debug() << "File::readMetadata()" << std::endl;
+  oops::Log::trace() << "File::readMetadata()" << std::endl;
   if (fileMode_ == netCDF::NcFile::read) {
     readDimensions(metadata);  // Should be called before readVariables()
     readVariables(metadata, varNames);
@@ -86,7 +86,7 @@ void monio::File::readMetadata(Metadata& metadata,
 }
 
 void monio::File::readDimensions(Metadata& metadata) {
-  oops::Log::debug() << "File::readDimensions()" << std::endl;
+  oops::Log::trace() << "File::readDimensions()" << std::endl;
   if (fileMode_ == netCDF::NcFile::read) {
     std::multimap<std::string, netCDF::NcDim> ncDimsMap = getFile().getDims();
     for (auto const& ncDimPair : ncDimsMap) {
@@ -100,7 +100,7 @@ void monio::File::readDimensions(Metadata& metadata) {
 }
 
 void monio::File::readVariables(Metadata& metadata) {
-  oops::Log::debug() << "File::readVariables()" << std::endl;
+  oops::Log::trace() << "File::readVariables()" << std::endl;
   if (fileMode_ == netCDF::NcFile::read) {
     // Potentially process getFile().getGroups() OR getFile().getId() here?
     std::multimap<std::string, netCDF::NcVar> nvVarsMap = getFile().getVars();
@@ -116,7 +116,7 @@ void monio::File::readVariables(Metadata& metadata) {
 
 void monio::File::readVariables(Metadata& metadata,
                                 const std::vector<std::string>& variableNames) {
-  oops::Log::debug() << "File::readVariables()" << std::endl;
+  oops::Log::trace() << "File::readVariables()" << std::endl;
   if (fileMode_ == netCDF::NcFile::read) {
     // Potentially process getFile().getGroups() OR getFile().getId() here?
     std::multimap<std::string, netCDF::NcVar> nvVarsMap = getFile().getVars();
@@ -134,7 +134,7 @@ void monio::File::readVariables(Metadata& metadata,
 }
 
 void monio::File::readVariable(Metadata& metadata, netCDF::NcVar ncVar) {
-  oops::Log::debug() << "File::readVariable()" << std::endl;
+  oops::Log::trace() << "File::readVariable()" << std::endl;
   netCDF::NcType varType = ncVar.getType();
   std::string varName = ncVar.getName();
   std::shared_ptr<monio::Variable> var = nullptr;
@@ -214,7 +214,7 @@ void monio::File::readVariable(Metadata& metadata, netCDF::NcVar ncVar) {
 }
 
 void monio::File::readAttributes(Metadata& metadata) {
-  oops::Log::debug() << "File::readAttributes()" << std::endl;
+  oops::Log::trace() << "File::readAttributes()" << std::endl;
   if (fileMode_ == netCDF::NcFile::read) {
     std::multimap<std::string, netCDF::NcGroupAtt> ncAttrMap = getFile().getAtts();
     for (auto const& ncAttrPair : ncAttrMap) {
@@ -262,7 +262,7 @@ void monio::File::readAttributes(Metadata& metadata) {
 template<typename T>
 void monio::File::readSingleDatum(const std::string& varName,
                                   std::vector<T>& dataVec) {
-  oops::Log::debug() << "File::readSingleDatum()" << std::endl;
+  oops::Log::trace() << "File::readSingleDatum()" << std::endl;
   if (fileMode_ == netCDF::NcFile::read) {
     auto var = getFile().getVar(varName);
     var.getVar(dataVec.data());
@@ -284,7 +284,7 @@ void monio::File::readFieldDatum(const std::string& fieldName,
                                  const std::vector<size_t>& startVec,
                                  const std::vector<size_t>& countVec,
                                  std::vector<T>& dataVec) {
-  oops::Log::debug() << "File::readFieldDatum()" << std::endl;
+  oops::Log::trace() << "File::readFieldDatum()" << std::endl;
   if (fileMode_ == netCDF::NcFile::read) {
     auto var = getFile().getVar(fieldName);
     var.getVar(startVec, countVec, dataVec.data());
@@ -310,7 +310,7 @@ template void monio::File::readFieldDatum<int>(const std::string& varName,
 // Writing functions ///////////////////////////////////////////////////////////////////////////////
 
 void monio::File::writeMetadata(const Metadata& metadata) {
-  oops::Log::debug() << "File::writeMetadata()" << std::endl;
+  oops::Log::trace() << "File::writeMetadata()" << std::endl;
   if (fileMode_ != netCDF::NcFile::read) {
     writeDimensions(metadata);
     writeVariables(metadata);
@@ -322,7 +322,7 @@ void monio::File::writeMetadata(const Metadata& metadata) {
 }
 
 void monio::File::writeDimensions(const Metadata& metadata) {
-  oops::Log::debug() << "File::writeDimensions()" << std::endl;
+  oops::Log::trace() << "File::writeDimensions()" << std::endl;
   if (fileMode_ != netCDF::NcFile::read) {
     const std::map<std::string, int>& dimsMap = metadata.getDimensionsMap();
     const std::multimap<std::string, netCDF::NcDim> ncDimsMap = getFile().getDims();
@@ -338,7 +338,7 @@ void monio::File::writeDimensions(const Metadata& metadata) {
 }
 
 void monio::File::writeVariables(const Metadata& metadata) {
-  oops::Log::debug() << "File::writeVariables()" << std::endl;
+  oops::Log::trace() << "File::writeVariables()" << std::endl;
   if (fileMode_ != netCDF::NcFile::read) {
     const std::map<std::string, std::shared_ptr<Variable>>& varsMap = metadata.getVariablesMap();
     const std::multimap<std::string, netCDF::NcVar> ncVarsMap = getFile().getVars();
@@ -390,7 +390,7 @@ void monio::File::writeVariables(const Metadata& metadata) {
 }
 
 void monio::File::writeAttributes(const Metadata& metadata) {
-  oops::Log::debug() << "File::writeAttributes()" << std::endl;
+  oops::Log::trace() << "File::writeAttributes()" << std::endl;
   if (fileMode_ != netCDF::NcFile::read) {
     const std::map<std::string, std::shared_ptr<AttributeBase>>& globalAttrMap =
                                 metadata.getGlobalAttrsMap();
@@ -437,7 +437,7 @@ void monio::File::writeAttributes(const Metadata& metadata) {
 
 template<typename T>
 void monio::File::writeSingleDatum(const std::string &varName, const std::vector<T>& dataVec) {
-  oops::Log::debug() << "File::writeSingleDatum()" << std::endl;
+  oops::Log::trace() << "File::writeSingleDatum()" << std::endl;
   if (fileMode_ != netCDF::NcFile::read) {
     auto var = getFile().getVar(varName);
     var.putVar(dataVec.data());

--- a/src/monio/Metadata.cc
+++ b/src/monio/Metadata.cc
@@ -24,7 +24,7 @@
 #include "Utils.h"
 
 monio::Metadata::Metadata() {
-  oops::Log::debug() << "Metadata::Metadata()" << std::endl;
+  oops::Log::trace() << "Metadata::Metadata()" << std::endl;
 }
 
 bool monio::operator==(const monio::Metadata& lhs,
@@ -129,7 +129,7 @@ bool monio::operator==(const monio::Metadata& lhs,
 }
 
 const bool monio::Metadata::isDimDefined(const std::string& dimName) const {
-  oops::Log::debug() << "Metadata::isDimDefined()" << std::endl;
+  oops::Log::trace() << "Metadata::isDimDefined()" << std::endl;
   auto it = dimensions_.find(dimName);
   if (it != dimensions_.end()) {
     return true;
@@ -139,7 +139,7 @@ const bool monio::Metadata::isDimDefined(const std::string& dimName) const {
 }
 
 const int monio::Metadata::getDimension(const std::string& dimName) const {
-  oops::Log::debug() << "Metadata::getDimension()" << std::endl;
+  oops::Log::trace() << "Metadata::getDimension()" << std::endl;
   if (isDimDefined(dimName) == true) {
     return dimensions_.at(dimName);
   } else {
@@ -167,7 +167,7 @@ const std::string monio::Metadata::getDimensionName(const int dimValue) const {
 }
 
 std::shared_ptr<monio::Variable> monio::Metadata::getVariable(const std::string& varName) {
-  oops::Log::debug() << "Metadata::getVariable()> " << varName << std::endl;
+  oops::Log::trace() << "Metadata::getVariable()> " << varName << std::endl;
   auto it = variables_.find(varName);
   if (it != variables_.end()) {
     return variables_.at(varName);
@@ -179,7 +179,7 @@ std::shared_ptr<monio::Variable> monio::Metadata::getVariable(const std::string&
 
 const std::shared_ptr<monio::Variable>
       monio::Metadata::getVariable(const std::string& varName) const {
-  oops::Log::debug() << "Metadata::getVariable()> " << varName << std::endl;
+  oops::Log::trace() << "Metadata::getVariable()> " << varName << std::endl;
   auto it = variables_.find(varName);
   std::shared_ptr<monio::Variable> variable;
   if (it != variables_.end()) {
@@ -192,7 +192,7 @@ const std::shared_ptr<monio::Variable>
 
 std::vector<std::shared_ptr<monio::Variable>>
       monio::Metadata::getVariables(const std::vector<std::string>& varNames) {
-  oops::Log::debug() << "Metadata::getVariables()> " << std::endl;
+  oops::Log::trace() << "Metadata::getVariables()> " << std::endl;
   std::vector<std::shared_ptr<monio::Variable>> variables;
   for (const auto& varName : varNames) {
     variables.push_back(getVariable(varName));
@@ -202,7 +202,7 @@ std::vector<std::shared_ptr<monio::Variable>>
 
 const std::vector<std::shared_ptr<monio::Variable>>
       monio::Metadata::getVariables(const std::vector<std::string>& varNames) const {
-  oops::Log::debug() << "Metadata::getVariables()> " << std::endl;
+  oops::Log::trace() << "Metadata::getVariables()> " << std::endl;
   std::vector<std::shared_ptr<monio::Variable>> variables;
   for (const auto& varName : varNames) {
     variables.push_back(getVariable(varName));
@@ -211,7 +211,7 @@ const std::vector<std::shared_ptr<monio::Variable>>
 }
 
 std::vector<std::string> monio::Metadata::getVarStrAttrs(const std::string& attrName) {
-  oops::Log::debug() << "Metadata::getVarStrAttrs()" << std::endl;
+  oops::Log::trace() << "Metadata::getVarStrAttrs()" << std::endl;
   std::vector<std::string> varNames = getVariableNames();
   return getVarStrAttrs(varNames, attrName);
 }
@@ -219,7 +219,7 @@ std::vector<std::string> monio::Metadata::getVarStrAttrs(const std::string& attr
 const std::vector<std::string> monio::Metadata::getVarStrAttrs(
                                                   const std::vector<std::string>& varNames,
                                                   const std::string& attrName) const {
-  oops::Log::debug() << "Metadata::getVarStrAttrs()" << std::endl;
+  oops::Log::trace() << "Metadata::getVarStrAttrs()" << std::endl;
   std::vector<std::shared_ptr<monio::Variable>> variables = getVariables(varNames);
   std::vector<std::string> varStrAttrs;
   for (const auto& var : variables) {
@@ -235,7 +235,7 @@ const std::vector<std::string> monio::Metadata::getVarStrAttrs(
 }
 
 void monio::Metadata::addDimension(const std::string& dimName, const int value) {
-  oops::Log::debug() << "Metadata::addDimension()" << std::endl;
+  oops::Log::trace() << "Metadata::addDimension()" << std::endl;
   auto it = dimensions_.find(dimName);
   if (it == dimensions_.end()) {
     dimensions_.insert({dimName, value});
@@ -245,7 +245,7 @@ void monio::Metadata::addDimension(const std::string& dimName, const int value) 
 
 void monio::Metadata::addGlobalAttr(const std::string& attrName,
                                     std::shared_ptr<AttributeBase> attr) {
-  oops::Log::debug() << "Metadata::addGlobalAttr()" << std::endl;
+  oops::Log::trace() << "Metadata::addGlobalAttr()" << std::endl;
   auto it = globalAttrs_.find(attrName);
   if (it == globalAttrs_.end()) {
     globalAttrs_.insert({attrName, attr});
@@ -254,7 +254,7 @@ void monio::Metadata::addGlobalAttr(const std::string& attrName,
 
 void monio::Metadata::addVariable(const std::string& varName,
                                   std::shared_ptr<Variable> var) {
-  oops::Log::debug() << "Metadata::addVariable()" << std::endl;
+  oops::Log::trace() << "Metadata::addVariable()" << std::endl;
   auto it = variables_.find(varName);
   if (it == variables_.end()) {
     variables_.insert({varName, var});
@@ -262,12 +262,12 @@ void monio::Metadata::addVariable(const std::string& varName,
 }
 
 std::vector<std::string> monio::Metadata::getDimensionNames() {
-  oops::Log::debug() << "Metadata::getDimensionNames()" << std::endl;
+  oops::Log::trace() << "Metadata::getDimensionNames()" << std::endl;
   return utils::extractKeys(dimensions_);
 }
 
 std::vector<std::string> monio::Metadata::getVariableNames() {
-  oops::Log::debug() << "Metadata::getVariableNames()" << std::endl;
+  oops::Log::trace() << "Metadata::getVariableNames()" << std::endl;
   return utils::extractKeys(variables_);
 }
 
@@ -284,41 +284,41 @@ std::vector<std::string> monio::Metadata::findVariableNames(const std::string& s
 }
 
 std::vector<std::string> monio::Metadata::getGlobalAttrNames() {
-  oops::Log::debug() << "Metadata::getGlobalAttrNames()" << std::endl;
+  oops::Log::trace() << "Metadata::getGlobalAttrNames()" << std::endl;
   return utils::extractKeys(globalAttrs_);
 }
 
 std::map<std::string, int>& monio::Metadata::getDimensionsMap() {
-  oops::Log::debug() << "Metadata::getDimensionsMap()" << std::endl;
+  oops::Log::trace() << "Metadata::getDimensionsMap()" << std::endl;
   return dimensions_;
 }
 
 std::map<std::string, std::shared_ptr<monio::Variable>>&
                                       monio::Metadata::getVariablesMap() {
-  oops::Log::debug() << "Metadata::getVariablesMap()" << std::endl;
+  oops::Log::trace() << "Metadata::getVariablesMap()" << std::endl;
   return variables_;
 }
 
 std::map<std::string, std::shared_ptr<monio::AttributeBase>>&
                                       monio::Metadata::getGlobalAttrsMap() {
-  oops::Log::debug() << "Metadata::getGlobalAttrsMap()" << std::endl;
+  oops::Log::trace() << "Metadata::getGlobalAttrsMap()" << std::endl;
   return globalAttrs_;
 }
 
 const std::map<std::string, int>& monio::Metadata::getDimensionsMap() const {
-  oops::Log::debug() << "Metadata::getDimensionsMap()" << std::endl;
+  oops::Log::trace() << "Metadata::getDimensionsMap()" << std::endl;
   return dimensions_;
 }
 
 const std::map<std::string, std::shared_ptr<monio::Variable>>&
                                             monio::Metadata::getVariablesMap() const {
-  oops::Log::debug() << "Metadata::getVariablesMap()" << std::endl;
+  oops::Log::trace() << "Metadata::getVariablesMap()" << std::endl;
   return variables_;
 }
 
 const std::map<std::string, std::shared_ptr<monio::AttributeBase>>&
                                             monio::Metadata::getGlobalAttrsMap() const {
-  oops::Log::debug() << "Metadata::getGlobalAttrsMap()" << std::endl;
+  oops::Log::trace() << "Metadata::getGlobalAttrsMap()" << std::endl;
   return globalAttrs_;
 }
 
@@ -340,7 +340,7 @@ int monio::Metadata::getVariableConvention() {
 
 void monio::Metadata::removeAllButTheseVariables(
     const std::vector<std::string>& varNames) {
-  oops::Log::debug() << "Metadata::removeAllButTheseVariables()" << std::endl;
+  oops::Log::trace() << "Metadata::removeAllButTheseVariables()" << std::endl;
   std::vector<std::string> variableKeys = utils::extractKeys(variables_);
   for (const std::string& variableKey : variableKeys) {
     if (utils::findInVector(varNames, variableKey) == false) {
@@ -350,7 +350,7 @@ void monio::Metadata::removeAllButTheseVariables(
 }
 
 void monio::Metadata::deleteDimension(const std::string& dimName) {
-  oops::Log::debug() << "Metadata::deleteDimension()" << std::endl;
+  oops::Log::trace() << "Metadata::deleteDimension()" << std::endl;
   auto itDim = dimensions_.find(dimName);
   if (itDim != dimensions_.end()) {
     dimensions_.erase(dimName);
@@ -361,7 +361,7 @@ void monio::Metadata::deleteDimension(const std::string& dimName) {
 }
 
 void monio::Metadata::deleteVariable(const std::string& varName) {
-  oops::Log::debug() << "Metadata::deleteVariable()" << std::endl;
+  oops::Log::trace() << "Metadata::deleteVariable()" << std::endl;
   auto it = variables_.find(varName);
   if (it != variables_.end()) {
     variables_.erase(varName);
@@ -372,14 +372,14 @@ void monio::Metadata::deleteVariable(const std::string& varName) {
 }
 
 void monio::Metadata::clear() {
-  oops::Log::debug() << "Metadata::clear()" << std::endl;
+  oops::Log::trace() << "Metadata::clear()" << std::endl;
   // dimensions_.clear();  // Dimensions are required for correct writing of subsequent variables.
   variables_.clear();
   globalAttrs_.clear();
 }
 
 void monio::Metadata::clearGlobalAttributes() {
-  oops::Log::debug() << "Metadata::clearGlobalAttributes()" << std::endl;
+  oops::Log::trace() << "Metadata::clearGlobalAttributes()" << std::endl;
   globalAttrs_.clear();
 }
 

--- a/src/monio/Monio.cc
+++ b/src/monio/Monio.cc
@@ -29,7 +29,7 @@ namespace  {
 }
 
 monio::Monio& monio::Monio::get() {
-  oops::Log::debug() << "Monio::get()" << std::endl;
+  oops::Log::trace() << "Monio::get()" << std::endl;
   if (this_ == nullptr) {
     this_ = new Monio(atlas::mpi::comm(), consts::kMPIRankOwner);
   }
@@ -47,7 +47,7 @@ void monio::Monio::readState(atlas::FieldSet& localFieldSet,
                             const std::vector<consts::FieldMetadata>& fieldMetadataVec,
                             const std::string& filePath,
                             const util::DateTime& dateTime) {
-  oops::Log::debug() << "Monio::readState()" << std::endl;
+  oops::Log::trace() << "Monio::readState()" << std::endl;
   if (localFieldSet.size() == 0) {
     Monio::get().closeFiles();
     utils::throwException("Monio::readState()> localFieldSet has zero fields...");
@@ -72,7 +72,7 @@ void monio::Monio::readState(atlas::FieldSet& localFieldSet,
               readName = fieldMetadata.jediName;
             }
             if (utils::findInVector(consts::kMissingVariableNames, readName) == false) {
-              oops::Log::debug() << "Monio::readState() processing data for> \"" <<
+              oops::Log::trace() << "Monio::readState() processing data for> \"" <<
                                     readName << "\"..." << std::endl;
               // Read fields into memory
               reader_.readDatumAtTime(fileData, readName, dateTime,
@@ -107,7 +107,7 @@ void monio::Monio::readState(atlas::FieldSet& localFieldSet,
 void monio::Monio::readIncrements(atlas::FieldSet& localFieldSet,
                             const std::vector<consts::FieldMetadata>& fieldMetadataVec,
                             const std::string& filePath) {
-  oops::Log::debug() << "Monio::readIncrements()" << std::endl;
+  oops::Log::trace() << "Monio::readIncrements()" << std::endl;
   if (localFieldSet.size() == 0) {
     Monio::get().closeFiles();
     utils::throwException("Monio::readIncrements()> localFieldSet has zero fields...");
@@ -132,7 +132,7 @@ void monio::Monio::readIncrements(atlas::FieldSet& localFieldSet,
             if (variableConvention == consts::eJediConvention) {
               readName = fieldMetadata.jediName;
             }
-            oops::Log::debug() << "Monio::readIncrements() processing data for> \"" <<
+            oops::Log::trace() << "Monio::readIncrements() processing data for> \"" <<
                                   readName << "\"..." << std::endl;
             // Read fields into memory
             reader_.readFullDatum(fileData, readName);
@@ -164,7 +164,7 @@ void monio::Monio::writeIncrements(const atlas::FieldSet& localFieldSet,
                                    const std::vector<consts::FieldMetadata>& fieldMetadataVec,
                                    const std::string& filePath,
                                    const bool isLfricConvention) {
-  oops::Log::debug() << "Monio::writeIncrements()" << std::endl;
+  oops::Log::trace() << "Monio::writeIncrements()" << std::endl;
   if (localFieldSet.size() == 0) {
     Monio::get().closeFiles();
     utils::throwException("Monio::writeIncrements()> localFieldSet has zero fields...");
@@ -197,7 +197,7 @@ void monio::Monio::writeIncrements(const atlas::FieldSet& localFieldSet,
             utils::throwException("Monio::writeIncrements()> "
                                   "Field metadata configuration error...");
           }
-          oops::Log::debug() << "Monio::writeIncrements() processing data for> \"" <<
+          oops::Log::trace() << "Monio::writeIncrements() processing data for> \"" <<
                                 writeName << "\"..." << std::endl;
 
           atlasWriter_.populateFileDataWithField(fileData,
@@ -227,7 +227,7 @@ void monio::Monio::writeState(const atlas::FieldSet& localFieldSet,
                               const std::vector<consts::FieldMetadata>& fieldMetadataVec,
                               const std::string& filePath,
                               const bool isLfricConvention) {
-  oops::Log::debug() << "Monio::writeState()" << std::endl;
+  oops::Log::trace() << "Monio::writeState()" << std::endl;
   if (localFieldSet.size() == 0) {
     Monio::get().closeFiles();
     utils::throwException("Monio::writeState()> localFieldSet has zero fields...");
@@ -259,7 +259,7 @@ void monio::Monio::writeState(const atlas::FieldSet& localFieldSet,
             Monio::get().closeFiles();
             utils::throwException("Monio::writeState()> Field metadata configuration error...");
           }
-          oops::Log::debug() << "Monio::writeState() processing data for> \"" <<
+          oops::Log::trace() << "Monio::writeState() processing data for> \"" <<
                                   writeName << "\"..." << std::endl;
 
           atlasWriter_.populateFileDataWithField(fileData,
@@ -287,7 +287,7 @@ void monio::Monio::writeState(const atlas::FieldSet& localFieldSet,
 
 void monio::Monio::writeFieldSet(const atlas::FieldSet& localFieldSet,
                                  const std::string& filePath) {
-  oops::Log::debug() << "Monio::writeFieldSet()" << std::endl;
+  oops::Log::trace() << "Monio::writeFieldSet()" << std::endl;
   if (localFieldSet.size() == 0) {
     Monio::get().closeFiles();
     utils::throwException("Monio::writeFieldSet()> localFieldSet has zero fields...");
@@ -318,7 +318,7 @@ void monio::Monio::writeFieldSet(const atlas::FieldSet& localFieldSet,
 }
 
 void monio::Monio::closeFiles() {
-  oops::Log::debug() << "Monio::closeFiles()" << std::endl;
+  oops::Log::trace() << "Monio::closeFiles()" << std::endl;
   reader_.closeFile();
   writer_.closeFile();
 }
@@ -326,7 +326,7 @@ void monio::Monio::closeFiles() {
 int monio::Monio::initialiseFile(const atlas::Grid& grid,
                                  const std::string& filePath,
                                  bool doCreateDateTimes) {
-  oops::Log::debug() << "Monio::initialiseFile()" << std::endl;
+  oops::Log::trace() << "Monio::initialiseFile()" << std::endl;
   int variableConvention = consts::eLfricConvention;  // LFRic convention is default
   if (mpiCommunicator_.rank() == mpiRankOwner_) {
     FileData& fileData = createFileData(grid.name(), filePath);
@@ -361,12 +361,12 @@ monio::Monio::Monio(const eckit::mpi::Comm& mpiCommunicator,
       writer_(mpiCommunicator, mpiRankOwner_),
       atlasReader_(mpiCommunicator, mpiRankOwner_),
       atlasWriter_(mpiCommunicator, mpiRankOwner_) {
-  oops::Log::debug() << "Monio::Monio()" << std::endl;
+  oops::Log::trace() << "Monio::Monio()" << std::endl;
 }
 
 monio::FileData& monio::Monio::createFileData(const std::string& gridName,
                                               const std::string& filePath) {
-  oops::Log::debug() << "Monio::createFileData()" << std::endl;
+  oops::Log::trace() << "Monio::createFileData()" << std::endl;
   auto it = filesData_.find(gridName);
 
   if (it != filesData_.end()) {
@@ -378,7 +378,7 @@ monio::FileData& monio::Monio::createFileData(const std::string& gridName,
 }
 
 monio::FileData monio::Monio::getFileData(const std::string& gridName) {
-  oops::Log::debug() << "Monio::getFileData()" << std::endl;
+  oops::Log::trace() << "Monio::getFileData()" << std::endl;
   auto it = filesData_.find(gridName);
   if (it != filesData_.end()) {
     return FileData(it->second);
@@ -387,7 +387,7 @@ monio::FileData monio::Monio::getFileData(const std::string& gridName) {
 }
 
 void monio::Monio::createLfricAtlasMap(FileData& fileData, const atlas::CubedSphereGrid& grid) {
-  oops::Log::debug() << "Monio::createLfricAtlasMap()" << std::endl;
+  oops::Log::trace() << "Monio::createLfricAtlasMap()" << std::endl;
   if (mpiCommunicator_.rank() == mpiRankOwner_) {
     if (fileData.getLfricAtlasMap().size() == 0) {
       reader_.readFullData(fileData, consts::kLfricCoordVarNames);
@@ -403,7 +403,7 @@ void monio::Monio::createLfricAtlasMap(FileData& fileData, const atlas::CubedSph
 void monio::Monio::createDateTimes(FileData& fileData,
                              const std::string& timeVarName,
                              const std::string& timeOriginName) {
-  oops::Log::debug() << "Monio::createDateTimes()" << std::endl;
+  oops::Log::trace() << "Monio::createDateTimes()" << std::endl;
   if (mpiCommunicator_.rank() == mpiRankOwner_) {
     if (fileData.getDateTimes().size() == 0) {
       std::shared_ptr<Variable> timeVar = fileData.getMetadata().getVariable(timeVarName);
@@ -436,7 +436,7 @@ void monio::Monio::createDateTimes(FileData& fileData,
 }
 
 void monio::Monio::cleanFileData(FileData& fileData) {
-  oops::Log::debug() << "Monio::cleanFileData()" << std::endl;
+  oops::Log::trace() << "Monio::cleanFileData()" << std::endl;
   if (mpiCommunicator_.rank() == mpiRankOwner_) {
     fileData.getMetadata().clearGlobalAttributes();
     fileData.getMetadata().deleteDimension(std::string(consts::kTimeDimName));

--- a/src/monio/Reader.cc
+++ b/src/monio/Reader.cc
@@ -29,7 +29,7 @@ monio::Reader::Reader(const eckit::mpi::Comm& mpiCommunicator,
                       const std::string& filePath):
     mpiCommunicator_(mpiCommunicator),
     mpiRankOwner_(mpiRankOwner) {
-  oops::Log::debug() << "Reader::Reader()" << std::endl;
+  oops::Log::trace() << "Reader::Reader()" << std::endl;
   openFile(filePath);
 }
 
@@ -37,11 +37,11 @@ monio::Reader::Reader(const eckit::mpi::Comm& mpiCommunicator,
                       const int mpiRankOwner):
     mpiCommunicator_(mpiCommunicator),
     mpiRankOwner_(mpiRankOwner) {
-  oops::Log::debug() << "Reader::Reader()" << std::endl;
+  oops::Log::trace() << "Reader::Reader()" << std::endl;
 }
 
 void monio::Reader::openFile(const std::string& filePath) {
-  oops::Log::debug() << "Reader::openFile()" << std::endl;
+  oops::Log::trace() << "Reader::openFile()" << std::endl;
   if (mpiCommunicator_.rank() == mpiRankOwner_) {
     if (filePath.size() != 0) {
       try {
@@ -55,7 +55,7 @@ void monio::Reader::openFile(const std::string& filePath) {
 }
 
 void monio::Reader::closeFile() {
-  oops::Log::debug() << "Reader::closeFile()" << std::endl;
+  oops::Log::trace() << "Reader::closeFile()" << std::endl;
   if (mpiCommunicator_.rank() == mpiRankOwner_) {
     if (isOpen() == true) {
       getFile().close();
@@ -69,7 +69,7 @@ bool monio::Reader::isOpen() {
 }
 
 void monio::Reader::readMetadata(FileData& fileData) {
-  oops::Log::debug() << "Reader::readMetadata()" << std::endl;
+  oops::Log::trace() << "Reader::readMetadata()" << std::endl;
   if (mpiCommunicator_.rank() == mpiRankOwner_) {
     getFile().readMetadata(fileData.getMetadata());
   }
@@ -79,7 +79,7 @@ void monio::Reader::readDatumAtTime(FileData& fileData,
                                    const std::string& varName,
                                    const util::DateTime& dateToRead,
                                    const std::string& timeDimName) {
-  oops::Log::debug() << "Reader::readDatumAtTime()" << std::endl;
+  oops::Log::trace() << "Reader::readDatumAtTime()" << std::endl;
   if (mpiCommunicator_.rank() == mpiRankOwner_) {
     size_t timeStep = findTimeStep(fileData, dateToRead);
     readDatumAtTime(fileData, varName, timeStep, timeDimName);
@@ -90,7 +90,7 @@ void monio::Reader::readDatumAtTime(FileData& fileData,
                                    const std::string& varName,
                                    const size_t timeStep,
                                    const std::string& timeDimName) {
-  oops::Log::debug() << "Reader::readDatumAtTime()" << std::endl;
+  oops::Log::trace() << "Reader::readDatumAtTime()" << std::endl;
   if (mpiCommunicator_.rank() == mpiRankOwner_) {
     if (fileData.getData().isContainerPresent(varName) == false) {
       std::shared_ptr<Variable> variable = fileData.getMetadata().getVariable(varName);
@@ -152,14 +152,14 @@ void monio::Reader::readDatumAtTime(FileData& fileData,
            "An exception occurred while creating data container...");
       }
     } else {
-      oops::Log::debug() << "Reader::readDatumAtTime()> DataContainer \""
+      oops::Log::trace() << "Reader::readDatumAtTime()> DataContainer \""
         << varName << "\" aleady defined." << std::endl;
     }
   }
 }
 
 void monio::Reader::readAllData(FileData& fileData) {
-  oops::Log::debug() << "Reader::readAllData()" << std::endl;
+  oops::Log::trace() << "Reader::readAllData()" << std::endl;
   if (mpiCommunicator_.rank() == mpiRankOwner_) {
     std::vector<std::string> varNames = fileData.getMetadata().getVariableNames();
     readFullData(fileData, varNames);
@@ -168,7 +168,7 @@ void monio::Reader::readAllData(FileData& fileData) {
 
 void monio::Reader::readFullData(FileData& fileData,
                                  const std::vector<std::string>& varNames) {
-  oops::Log::debug() << "Reader::readFullData()" << std::endl;
+  oops::Log::trace() << "Reader::readFullData()" << std::endl;
   if (mpiCommunicator_.rank() == mpiRankOwner_) {
     for (const auto& varName : varNames) {
       readFullDatum(fileData, varName);
@@ -178,7 +178,7 @@ void monio::Reader::readFullData(FileData& fileData,
 
 void monio::Reader::readFullDatum(FileData& fileData,
                                   const std::string& varName) {
-  oops::Log::debug() << "Reader::readFullDatum()" << std::endl;
+  oops::Log::trace() << "Reader::readFullDatum()" << std::endl;
   if (mpiCommunicator_.rank() == mpiRankOwner_) {
     std::shared_ptr<DataContainerBase> dataContainer = nullptr;
     std::shared_ptr<Variable> variable = fileData.getMetadata().getVariable(varName);
@@ -225,7 +225,7 @@ void monio::Reader::readFullDatum(FileData& fileData,
 }
 
 monio::File& monio::Reader::getFile() {
-  oops::Log::debug() << "Reader::getFile()" << std::endl;
+  oops::Log::trace() << "Reader::getFile()" << std::endl;
   if (isOpen() == false) {
     utils::throwException("Reader::getFile()> File has not been initialised...");
   }
@@ -235,7 +235,7 @@ monio::File& monio::Reader::getFile() {
 std::vector<std::shared_ptr<monio::DataContainerBase>> monio::Reader::getCoordData(
                                                              FileData& fileData,
                                                        const std::vector<std::string>& coordNames) {
-  oops::Log::debug() << "Reader::getCoordData()" << std::endl;
+  oops::Log::trace() << "Reader::getCoordData()" << std::endl;
   if (coordNames.size() == 2) {
     std::vector<std::shared_ptr<monio::DataContainerBase>> coordContainers;
     if (mpiCommunicator_.rank() == mpiRankOwner_) {
@@ -256,9 +256,9 @@ std::vector<std::shared_ptr<monio::DataContainerBase>> monio::Reader::getCoordDa
 }
 
 size_t monio::Reader::findTimeStep(const FileData& fileData, const util::DateTime& dateTime) {
-  oops::Log::debug() << "Reader::findTimeStep()" << std::endl;
+  oops::Log::trace() << "Reader::findTimeStep()" << std::endl;
   if (fileData.getDateTimes().size() == 0) {
-    oops::Log::debug() << "Reader::findTimeStep()> Date times not initialised..." << std::endl;
+    oops::Log::trace() << "Reader::findTimeStep()> Date times not initialised..." << std::endl;
     closeFile();
     utils::throwException("Reader::findTimeStep()> Date times not initialised...");
   }

--- a/src/monio/Writer.cc
+++ b/src/monio/Writer.cc
@@ -25,7 +25,7 @@ monio::Writer::Writer(const eckit::mpi::Comm& mpiCommunicator,
                       const std::string& filePath) :
     mpiCommunicator_(mpiCommunicator),
     mpiRankOwner_(mpiRankOwner) {
-  oops::Log::debug() << "Writer::Writer()" << std::endl;
+  oops::Log::trace() << "Writer::Writer()" << std::endl;
   openFile(filePath);
 }
 
@@ -33,11 +33,11 @@ monio::Writer::Writer(const eckit::mpi::Comm& mpiCommunicator,
                       const int mpiRankOwner) :
     mpiCommunicator_(mpiCommunicator),
     mpiRankOwner_(mpiRankOwner) {
-  oops::Log::debug() << "Writer::Writer()" << std::endl;
+  oops::Log::trace() << "Writer::Writer()" << std::endl;
 }
 
 void monio::Writer::openFile(const std::string& filePath) {
-  oops::Log::debug() << "Writer::openFile() \"" << filePath << "\"..." << std::endl;
+  oops::Log::trace() << "Writer::openFile() \"" << filePath << "\"..." << std::endl;
   if (mpiCommunicator_.rank() == mpiRankOwner_) {
     if (filePath.size() != 0) {
       try {
@@ -51,7 +51,7 @@ void monio::Writer::openFile(const std::string& filePath) {
 }
 
 void monio::Writer::closeFile() {
-  oops::Log::debug() << "Writer::closeFile()" << std::endl;
+  oops::Log::trace() << "Writer::closeFile()" << std::endl;
   if (mpiCommunicator_.rank() == mpiRankOwner_) {
     if (isOpen() == true) {
       getFile().close();
@@ -65,14 +65,14 @@ bool monio::Writer::isOpen() {
 }
 
 void monio::Writer::writeMetadata(const Metadata& metadata) {
-  oops::Log::debug() << "Writer::writeMetadata()" << std::endl;
+  oops::Log::trace() << "Writer::writeMetadata()" << std::endl;
   if (mpiCommunicator_.rank() == mpiRankOwner_) {
     getFile().writeMetadata(metadata);
   }
 }
 
 void monio::Writer::writeData(const FileData& fileData) {
-  oops::Log::debug() << "Writer::writeVariablesData()" << std::endl;
+  oops::Log::trace() << "Writer::writeVariablesData()" << std::endl;
   if (mpiCommunicator_.rank() == mpiRankOwner_) {
     const std::map<std::string, std::shared_ptr<DataContainerBase>>& dataContainerMap =
                                                                 fileData.getData().getContainers();
@@ -110,7 +110,7 @@ void monio::Writer::writeData(const FileData& fileData) {
 }
 
 monio::File& monio::Writer::getFile() {
-  oops::Log::debug() << "Writer::getFile()" << std::endl;
+  oops::Log::trace() << "Writer::getFile()" << std::endl;
   if (isOpen() == false) {
     utils::throwException("Writer::getFile()> File has not been initialised...");
   }


### PR DESCRIPTION
# Description

Debug output can get cluttered with function name prints. It seems more appropriate that these are `trace` prints.

(`find . -type f -exec sed -i 's/oops::Log::debug() << "\([A-Za-z]\+\)::\([A-Za-z]\+\)()/oops::Log::trace() << "\1::\2()/g' {} \;`)


Resolves #39 