### PR TITLE
Give information when a time cannot be found in a file.

### DIFF
--- a/src/monio/Reader.cc
+++ b/src/monio/Reader.cc
@@ -277,7 +277,8 @@ size_t monio::Reader::findTimeStep(const FileData& fileData, const util::DateTim
             << "  Times available: {";
 
   for (const auto& time : fileData.getDateTimes()) {
-    msgStream << time.toString() << ", ";
+    msgStream << time.toString() << ", " << std::endl
+              << "                    ";
   }
   msgStream << "}" << std::endl;
 

--- a/src/monio/Reader.cc
+++ b/src/monio/Reader.cc
@@ -277,7 +277,7 @@ size_t monio::Reader::findTimeStep(const FileData& fileData, const util::DateTim
             << "  Times available:" << std::endl;
 
   for (const auto& time : fileData.getDateTimes()) {
-    msgStream << "  -" << time.toString() << std::endl;
+    msgStream << "  - " << time.toString() << std::endl;
   }
 
   utils::throwException(msgStream.str());

--- a/src/monio/Reader.cc
+++ b/src/monio/Reader.cc
@@ -274,13 +274,11 @@ size_t monio::Reader::findTimeStep(const FileData& fileData, const util::DateTim
   std::stringstream msgStream;
   msgStream << "Reader::findTimeStep()> DateTime specified not located in file..." << std::endl
             << "  Time specified: " << dateTime.toString() << std::endl
-            << "  Times available: {";
+            << "  Times available:" << std::endl;
 
   for (const auto& time : fileData.getDateTimes()) {
-    msgStream << time.toString() << ", " << std::endl
-              << "                    ";
+    msgStream << "  -" << time.toString() << std::endl;
   }
-  msgStream << "}" << std::endl;
 
   utils::throwException(msgStream.str());
 }

--- a/src/monio/Reader.cc
+++ b/src/monio/Reader.cc
@@ -268,6 +268,18 @@ size_t monio::Reader::findTimeStep(const FileData& fileData, const util::DateTim
       return timeStep;
     }
   }
+
+  // Otherwise - time not found in the file. Throw a descriptive error.
   closeFile();
-  utils::throwException("Reader::findTimeStep()> DateTime specified not located in file...");
+  std::stringstream msgStream;
+  msgStream << "Reader::findTimeStep()> DateTime specified not located in file..." << std::endl
+            << "  Time specified: " << dateTime.toString() << std::endl
+            << "  Times available: {";
+
+  for (const auto& time : fileData.getDateTimes()) {
+    msgStream << time.toString() << ", ";
+  }
+  msgStream << "}" << std::endl;
+
+  utils::throwException(msgStream.str());
 }


### PR DESCRIPTION
## Description

When a time cannot be found in a file, MONIO throws: 

```
Reader::findTimeStep()> DateTime specified not located in file...
```

But this doesn't give any information on why the time is not in the file, so it takes some investigating. This PR changes this so that MONIO outputs what times it has available, and what was requested, so it can be compared.

```
4: Reader::findTimeStep()> DateTime specified not located in file...
4:   Time specified: 2021-06-01T10:00:00Z
4:   Times available:
4:   - 2021-06-01T22:00:00Z
4:   - 2021-06-01T23:00:00Z
4:   - 2021-06-02T00:00:00Z
4:   - 2021-06-02T01:00:00Z
4:   - 2021-06-02T02:00:00Z
4:   - 2021-06-02T03:00:00Z
4:   - 2021-06-02T04:00:00Z
4:   - 2021-06-02T05:00:00Z
4:   - 2021-06-02T06:00:00Z
4:   - 2021-06-02T07:00:00Z
4:   - 2021-06-02T08:00:00Z
4:   - 2021-06-02T09:00:00Z
4:   - 2021-06-02T10:00:00Z
4:   - 2021-06-02T11:00:00Z
4:   - 2021-06-02T12:00:00Z
4:   - 2021-06-02T13:00:00Z
4:   - 2021-06-02T14:00:00Z
4:   - 2021-06-02T15:00:00Z
```

## Issue

Resolves #46 