### PR TITLE
[bugfix] I/O processing procedure: fixed bug (memory leakage)

### DIFF
--- a/src/monio/File.cc
+++ b/src/monio/File.cc
@@ -53,8 +53,10 @@ void monio::File::close() {
   } else if (fileMode_ == netCDF::NcFile::write) {
     oops::Log::debug() << "write" << std::endl;
   }
-  getFile().close();
-  dataFile_.release();
+  if (dataFile_ != nullptr) {
+    getFile().close();
+    dataFile_.reset();
+  }
 }
 // Reading functions ///////////////////////////////////////////////////////////////////////////////
 

--- a/src/monio/Monio.cc
+++ b/src/monio/Monio.cc
@@ -319,8 +319,12 @@ void monio::Monio::writeFieldSet(const atlas::FieldSet& localFieldSet,
 
 void monio::Monio::closeFiles() {
   oops::Log::trace() << "Monio::closeFiles()" << std::endl;
-  reader_.closeFile();
-  writer_.closeFile();
+  if (reader_.isOpen() == true) {
+    reader_.closeFile();
+  }
+  if (writer_.isOpen() == true) {
+    writer_.closeFile();
+  }
 }
 
 int monio::Monio::initialiseFile(const atlas::Grid& grid,

--- a/src/monio/Reader.cc
+++ b/src/monio/Reader.cc
@@ -59,7 +59,7 @@ void monio::Reader::closeFile() {
   if (mpiCommunicator_.rank() == mpiRankOwner_) {
     if (isOpen() == true) {
       getFile().close();
-      file_.release();
+      file_.reset();
     }
   }
 }

--- a/src/monio/Writer.cc
+++ b/src/monio/Writer.cc
@@ -55,7 +55,7 @@ void monio::Writer::closeFile() {
   if (mpiCommunicator_.rank() == mpiRankOwner_) {
     if (isOpen() == true) {
       getFile().close();
-      file_.release();
+      file_.reset();
     }
   }
 }


### PR DESCRIPTION
<br>

## Description
<br>

This PR is intended to fix a bug (memory leakage) in the I/O processing procedure part of the MONIO package

Recently, debugging/profiling of the application `lfricjedi_hofx.x` (OOPS class: `oops::HofX4D`) has been carried out by using the AddressSanitizer (ASan) tool.

During this investigation, a few memory leaks have been identified.
A subset of them are associated with the I/O processing procedure part of the MONIO package.
<br>

_* debugging/profiling (before)_

The output of the debugging/profiling can be found [here](http://fcm1/cylc-review/view/lmilazzo?&suite=lfricjedi_241105_t01&no_fuzzy_time=0&path=log/job/1/ctest_jjtests_hofx_atms__exz_gnu_asan/02/job.out#21586).
<br>

_* solution:_

The memory leaks occurs because the resources allocated for the data structure `dataFile_` are not correctly deallocated at the end.

The bug/issue is related with the call of the destructor of `std::unique_ptr`, in particular it is related with the difference between the two methods `std::unique_ptr::release()` and `std::unique_ptr::reset()`.
For details see [here](https://cplusplus.com/reference/memory/unique_ptr/release/), [here](https://cplusplus.com/reference/memory/unique_ptr/reset/), and [here](https://stackoverflow.com/questions/25609457/does-unique-ptrrelease-call-the-destructor). 
<br>

_* debugging/profiling (after)_

The output of the debugging/profiling carried out after fixing the bug can be found [here](http://fcm1/cylc-review/view/lmilazzo?&suite=lfricjedi_241105_t01&no_fuzzy_time=0&path=log/job/1/ctest_jjtests_hofx_atms__exz_gnu_asan/03/job.out#21606).
<br><br>

### Issue(s) addressed

issue #48
<br><br>

### Acceptance Criteria (Definition of Done)

All the tests pass.
<br><br>
