### PR TITLE
Allow reading of states and increments for structured columns

### DIFF
--- a/src/monio/Monio.cc
+++ b/src/monio/Monio.cc
@@ -11,6 +11,7 @@
 #include <memory>
 #include <vector>
 
+#include "atlas/functionspace/StructuredColumns.h"
 #include "atlas/parallel/mpi/mpi.h"
 #include "oops/util/Duration.h"
 #include "oops/util/Logger.h"
@@ -60,9 +61,22 @@ void monio::Monio::readState(atlas::FieldSet& localFieldSet,
           atlas::Field globalField = utilsatlas::getGlobalField(localField);
           if (mpiCommunicator_.rank() == mpiRankOwner_) {
             auto& functionSpace = globalField.functionspace();
-            auto& grid = atlas::functionspace::NodeColumns(functionSpace).mesh().grid();
+
+            auto nc = atlas::functionspace::NodeColumns(functionSpace);
+            auto sc = atlas::functionspace::StructuredColumns(functionSpace);
+
+            atlas::Grid grid;
+            if (nc) {
+              grid = nc.mesh().grid();
+            } else if (sc) {
+              grid = sc.grid();
+            } else {
+              utils::throwException("Monio::readState()> FunctionSpace not an accepted type. "
+                                    "Accepted types: NodeColumns, StructuredColumns");
+            }
+
             // Initialise file
-            int variableConvention = initialiseFile(grid.name(), filePath, true);
+            int variableConvention = initialiseFile(grid, filePath, true);
             // getFileData returns a copy of FileData (with required LFRic mesh data), so read data
             // is discarded when FileData goes out-of-scope for reading subsequent fields.
             FileData fileData = getFileData(grid.name());
@@ -390,7 +404,7 @@ monio::FileData monio::Monio::getFileData(const std::string& gridName) {
   return FileData();  // This function is called by all PEs. A return is essential.
 }
 
-void monio::Monio::createLfricAtlasMap(FileData& fileData, const atlas::CubedSphereGrid& grid) {
+void monio::Monio::createLfricAtlasMap(FileData& fileData, const atlas::Grid& grid) {
   oops::Log::trace() << "Monio::createLfricAtlasMap()" << std::endl;
   if (mpiCommunicator_.rank() == mpiRankOwner_) {
     if (fileData.getLfricAtlasMap().size() == 0) {

--- a/src/monio/Monio.cc
+++ b/src/monio/Monio.cc
@@ -62,7 +62,6 @@ void monio::Monio::readState(atlas::FieldSet& localFieldSet,
           if (mpiCommunicator_.rank() == mpiRankOwner_) {
             auto& functionSpace = globalField.functionspace();
             auto grid = utilsatlas::getGridFromFunctionSpace(functionSpace);
-
             // Initialise file
             int variableConvention = initialiseFile(grid, filePath, true);
             // getFileData returns a copy of FileData (with required LFRic mesh data), so read data

--- a/src/monio/Monio.cc
+++ b/src/monio/Monio.cc
@@ -11,7 +11,6 @@
 #include <memory>
 #include <vector>
 
-#include "atlas/functionspace/StructuredColumns.h"
 #include "atlas/parallel/mpi/mpi.h"
 #include "oops/util/Duration.h"
 #include "oops/util/Logger.h"

--- a/src/monio/Monio.cc
+++ b/src/monio/Monio.cc
@@ -62,18 +62,7 @@ void monio::Monio::readState(atlas::FieldSet& localFieldSet,
           if (mpiCommunicator_.rank() == mpiRankOwner_) {
             auto& functionSpace = globalField.functionspace();
 
-            auto nc = atlas::functionspace::NodeColumns(functionSpace);
-            auto sc = atlas::functionspace::StructuredColumns(functionSpace);
-
-            atlas::Grid grid;
-            if (nc) {
-              grid = nc.mesh().grid();
-            } else if (sc) {
-              grid = sc.grid();
-            } else {
-              utils::throwException("Monio::readState()> FunctionSpace not an accepted type. "
-                                    "Accepted types: NodeColumns, StructuredColumns");
-            }
+            auto grid = utilsatlas::getGridFromFunctionSpace(functionSpace);
 
             // Initialise file
             int variableConvention = initialiseFile(grid, filePath, true);
@@ -134,7 +123,7 @@ void monio::Monio::readIncrements(atlas::FieldSet& localFieldSet,
           atlas::Field globalField = utilsatlas::getGlobalField(localField);
           if (mpiCommunicator_.rank() == mpiRankOwner_) {
             auto& functionSpace = globalField.functionspace();
-            auto& grid = atlas::functionspace::NodeColumns(functionSpace).mesh().grid();
+            auto grid = utilsatlas::getGridFromFunctionSpace(functionSpace);
 
             // Initialise file
             int variableConvention = initialiseFile(grid.name(), filePath);
@@ -186,7 +175,7 @@ void monio::Monio::writeIncrements(const atlas::FieldSet& localFieldSet,
   if (filePath.length() != 0) {
     try {
       auto& functionSpace = localFieldSet[0].functionspace();
-      auto& grid = atlas::functionspace::NodeColumns(functionSpace).mesh().grid();
+      auto grid = utilsatlas::getGridFromFunctionSpace(functionSpace);
       FileData fileData = getFileData(grid.name());
       cleanFileData(fileData);  // Remove metadata required for reading, but not for writing.
       if (isLfricConvention == false) {
@@ -249,7 +238,7 @@ void monio::Monio::writeState(const atlas::FieldSet& localFieldSet,
   if (filePath.length() != 0) {
     try {
       auto& functionSpace = localFieldSet[0].functionspace();
-      auto& grid = atlas::functionspace::NodeColumns(functionSpace).mesh().grid();
+      auto grid = utilsatlas::getGridFromFunctionSpace(functionSpace);
       FileData fileData = getFileData(grid.name());
       cleanFileData(fileData);  // Remove metadata required for reading, but not for writing.
       if (isLfricConvention == false) {

--- a/src/monio/Monio.cc
+++ b/src/monio/Monio.cc
@@ -61,7 +61,6 @@ void monio::Monio::readState(atlas::FieldSet& localFieldSet,
           atlas::Field globalField = utilsatlas::getGlobalField(localField);
           if (mpiCommunicator_.rank() == mpiRankOwner_) {
             auto& functionSpace = globalField.functionspace();
-
             auto grid = utilsatlas::getGridFromFunctionSpace(functionSpace);
 
             // Initialise file

--- a/src/monio/Monio.cc
+++ b/src/monio/Monio.cc
@@ -124,7 +124,7 @@ void monio::Monio::readIncrements(atlas::FieldSet& localFieldSet,
             auto grid = utilsatlas::getGridFromFunctionSpace(functionSpace);
 
             // Initialise file
-            int variableConvention = initialiseFile(grid.name(), filePath);
+            int variableConvention = initialiseFile(grid, filePath);
             // getFileData returns a copy of FileData (with required LFRic mesh data), so read data
             // is discarded when FileData goes out-of-scope for reading subsequent fields.
             FileData fileData = getFileData(grid.name());

--- a/src/monio/Monio.h
+++ b/src/monio/Monio.h
@@ -89,7 +89,7 @@ class Monio {
   FileData getFileData(const std::string& gridName);
 
   /// \brief Creates and stores a map between Atlas and LFRic horizontal ordering.
-  void createLfricAtlasMap(FileData& fileData, const atlas::CubedSphereGrid& grid);
+  void createLfricAtlasMap(FileData& fileData, const atlas::Grid& grid);
 
   /// \brief Creates and stores date-times from a state file.
   void createDateTimes(FileData& fileData,

--- a/src/monio/UtilsAtlas.cc
+++ b/src/monio/UtilsAtlas.cc
@@ -165,6 +165,19 @@ atlas::FieldSet getGlobalFieldSet(const atlas::FieldSet& fieldSet) {
   }
 }
 
+atlas::Grid getGridFromFunctionSpace(const atlas::FunctionSpace& functionSpace) {
+  auto nc = atlas::functionspace::NodeColumns(functionSpace);
+  auto sc = atlas::functionspace::StructuredColumns(functionSpace);
+  if (nc) {
+    return nc.mesh().grid();
+  } else if (sc) {
+    return sc.grid();
+  } else {
+    utils::throwException("Monio::readState()> FunctionSpace not an accepted type. "
+                          "Accepted types: NodeColumns, StructuredColumns");
+  }
+}
+
 atlas::idx_t getHorizontalSize(const atlas::Field& field) {
   atlas::Field ghostField = field.functionspace().ghost();
   atlas::idx_t size = 0;

--- a/src/monio/UtilsAtlas.h
+++ b/src/monio/UtilsAtlas.h
@@ -43,6 +43,8 @@ namespace utilsatlas {
 
   atlas::Field getGlobalField(const atlas::Field& field);
 
+  atlas::Grid getGridFromFunctionSpace(const atlas::FunctionSpace& functionSpace);
+
   atlas::idx_t getHorizontalSize(const atlas::Field& field);  // Just 2D size. Any field.
   atlas::idx_t getGlobalDataSize(const atlas::Field& field);  // Full 3D size of global field.
 


### PR DESCRIPTION
Allows states and increments to be read with StructuredColumns, allowing for use with StructuredGrids used by regional models.

Contributes towards #51.

Is required by https://github.com/JCSDA-internal/lfric-jedi/pull/992.