### PR TITLE
Improve cmake targets for code linters

### DIFF
--- a/.cmakelintrc
+++ b/.cmakelintrc
@@ -1,0 +1,1 @@
+linelength=100

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,18 @@ env:
 
 
 jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install checkers/linters
+        run: |
+          python3 -m pip install cmakelint
+      - name: Run cmakelint
+        run: |
+          mapfile -t names < <(find -name 'CMakeLists.txt' -o -name '*.cmake')
+          cmakelint "${names[@]}"
+
   build1:
     if: |
       ( github.repository_owner == 'MetOffice' && github.event.pull_request.draft == false )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,9 +36,10 @@ find_package(atlas 0.20.2 REQUIRED)
 find_package(oops 1.0.0 REQUIRED)
 
 ## Export package info
-set(MONIO_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/src
-                       ${CMAKE_CURRENT_BINARY_DIR}/src
-                       ${oops_SOURCE_DIR}/src)
+set(MONIO_INCLUDE_DIRS
+  ${CMAKE_CURRENT_SOURCE_DIR}/src
+  ${CMAKE_CURRENT_BINARY_DIR}/src
+  ${oops_SOURCE_DIR}/src)
 
 set(MONIO_LIBRARIES monio)
 get_directory_property(MONIO_DEFINITIONS COMPILE_DEFINITIONS)

--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,4 +1,3 @@
 set noparent
 linelength=100
-filter=+build,-build/c++14,+legal,+readability,+runtime,+whitespace,-runtime/references,-runtime/printf
-
+filter=+build,-build/include,+legal,+readability,+runtime,-runtime/references,+whitespace,-whitespace/indent_namespace

--- a/src/monio/AtlasReader.cc
+++ b/src/monio/AtlasReader.cc
@@ -8,6 +8,10 @@
 ******************************************************************************/
 #include "AtlasReader.h"
 
+#include <memory>
+#include <string>
+#include <vector>
+
 #include "oops/util/Logger.h"
 
 #include "Utils.h"

--- a/src/monio/AtlasWriter.cc
+++ b/src/monio/AtlasWriter.cc
@@ -9,6 +9,10 @@
 ******************************************************************************/
 #include "AtlasWriter.h"
 
+#include <memory>
+#include <string>
+#include <vector>
+
 #include "atlas/grid/Iterator.h"
 #include "oops/util/Logger.h"
 

--- a/src/monio/AttributeBase.cc
+++ b/src/monio/AttributeBase.cc
@@ -8,6 +8,8 @@
 ******************************************************************************/
 #include "AttributeBase.h"
 
+#include <string>
+
 monio::AttributeBase::AttributeBase(
     const std::string& name,
     const int type):

--- a/src/monio/AttributeDouble.cc
+++ b/src/monio/AttributeDouble.cc
@@ -8,6 +8,8 @@
 ******************************************************************************/
 #include "AttributeDouble.h"
 
+#include <string>
+
 #include "Constants.h"
 
 monio::AttributeDouble::AttributeDouble(const std::string& name, const double value) :

--- a/src/monio/AttributeInt.cc
+++ b/src/monio/AttributeInt.cc
@@ -8,6 +8,8 @@
 ******************************************************************************/
 #include "AttributeInt.h"
 
+#include <string>
+
 #include "Constants.h"
 
 monio::AttributeInt::AttributeInt(const std::string& name, const int value) :

--- a/src/monio/AttributeString.cc
+++ b/src/monio/AttributeString.cc
@@ -8,6 +8,8 @@
 ******************************************************************************/
 #include "AttributeString.h"
 
+#include <string>
+
 #include "Constants.h"
 
 monio::AttributeString::AttributeString(const std::string& name,

--- a/src/monio/Data.cc
+++ b/src/monio/Data.cc
@@ -8,7 +8,10 @@
 ******************************************************************************/
 #include "Data.h"
 
+#include <map>
+#include <memory>
 #include <stdexcept>
+#include <string>
 #include <vector>
 
 #include "oops/util/Logger.h"

--- a/src/monio/DataContainerBase.cc
+++ b/src/monio/DataContainerBase.cc
@@ -8,6 +8,9 @@
 ******************************************************************************/
 #include "DataContainerBase.h"
 
+#include <string>
+#include <vector>
+
 monio::DataContainerBase::DataContainerBase(
     const std::string& name,
     const int type) :

--- a/src/monio/DataContainerDouble.cc
+++ b/src/monio/DataContainerDouble.cc
@@ -9,6 +9,8 @@
 #include "DataContainerDouble.h"
 
 #include <stdexcept>
+#include <string>
+#include <vector>
 
 #include "Constants.h"
 #include "Monio.h"

--- a/src/monio/DataContainerFloat.cc
+++ b/src/monio/DataContainerFloat.cc
@@ -9,6 +9,8 @@
 #include "DataContainerFloat.h"
 
 #include <stdexcept>
+#include <string>
+#include <vector>
 
 #include "Constants.h"
 #include "Monio.h"

--- a/src/monio/DataContainerInt.cc
+++ b/src/monio/DataContainerInt.cc
@@ -9,6 +9,8 @@
 #include "DataContainerInt.h"
 
 #include <stdexcept>
+#include <string>
+#include <vector>
 
 #include "Constants.h"
 #include "Monio.h"

--- a/src/monio/File.cc
+++ b/src/monio/File.cc
@@ -12,6 +12,8 @@
 #include <map>
 #include <memory>
 #include <stdexcept>
+#include <string>
+#include <vector>
 
 #include "oops/util/Logger.h"
 

--- a/src/monio/FileData.cc
+++ b/src/monio/FileData.cc
@@ -8,6 +8,8 @@
 ******************************************************************************/
 #include "FileData.h"
 
+#include <vector>
+
 monio::FileData::FileData() :
   data_(),
   metadata_() {}

--- a/src/monio/Metadata.cc
+++ b/src/monio/Metadata.cc
@@ -10,6 +10,8 @@
 
 #include <algorithm>
 #include <iomanip>
+#include <map>
+#include <memory>
 #include <stdexcept>
 #include <string>
 #include <utility>

--- a/src/monio/Monio.cc
+++ b/src/monio/Monio.cc
@@ -8,7 +8,10 @@
 ******************************************************************************/
 #include "Monio.h"
 
+#include <iostream>
 #include <memory>
+#include <string>
+#include <utility>
 #include <vector>
 
 #include "atlas/parallel/mpi/mpi.h"

--- a/src/monio/Reader.cc
+++ b/src/monio/Reader.cc
@@ -10,9 +10,12 @@
 
 #include <netcdf>
 #include <map>
+#include <memory>
 #include <sstream>
 #include <stdexcept>
+#include <string>
 #include <utility>
+#include <vector>
 
 #include "Constants.h"
 #include "DataContainerDouble.h"

--- a/src/monio/Utils.cc
+++ b/src/monio/Utils.cc
@@ -13,7 +13,10 @@
 #include <algorithm>
 #include <array>
 #include <fstream>
+#include <map>
 #include <memory>
+#include <string>
+#include <vector>
 
 #include "AttributeBase.h"
 #include "DataContainerBase.h"

--- a/src/monio/UtilsAtlas.cc
+++ b/src/monio/UtilsAtlas.cc
@@ -9,7 +9,10 @@
 #include "UtilsAtlas.h"
 
 #include <algorithm>
+#include <memory>
 #include <numeric>
+#include <string>
+#include <vector>
 
 #include "atlas/functionspace.h"
 #include "atlas/grid/Iterator.h"

--- a/src/monio/Variable.cc
+++ b/src/monio/Variable.cc
@@ -9,8 +9,12 @@
 #include "Variable.h"
 
 #include <algorithm>
+#include <map>
+#include <memory>
 #include <stdexcept>
+#include <string>
 #include <utility>
+#include <vector>
 
 #include "AttributeInt.h"
 #include "AttributeString.h"

--- a/src/monio/Writer.cc
+++ b/src/monio/Writer.cc
@@ -10,7 +10,9 @@
 
 #include <netcdf>
 #include <map>
+#include <memory>
 #include <stdexcept>
+#include <string>
 
 #include "Constants.h"
 #include "DataContainerDouble.h"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,13 +12,7 @@ message(STATUS "PROJECT_BINARY_DIR: ${PROJECT_BINARY_DIR}")
 message(STATUS "CMAKE_CURRENT_SOURCE_DIR: ${CMAKE_CURRENT_SOURCE_DIR}")
 message(STATUS "CMAKE_CURRENT_BINARY_DIR: ${CMAKE_CURRENT_BINARY_DIR}")
 
-execute_process(COMMAND ${CMAKE_COMMAND} -E copy
-                        ${PROJECT_SOURCE_DIR}/test/utils/cpplint.py
-                        ${CMAKE_BINARY_DIR}/bin/monio_cpplint.py)
-
-ecbuild_add_resources(TARGET       monio_test_scripts
-                      SOURCES_PACK ${monio_test_input}
-                                   ${PROJECT_SOURCE_DIR}/test/utils/cpplint.py)
+ecbuild_add_resources(TARGET monio_test_scripts SOURCES_PACK ${monio_test_input})
 
 if(NOT DEFINED MONIO_TESTFILES_DIR)
   if(DEFINED ENV{MONIO_TESTFILES_DIR})
@@ -62,17 +56,31 @@ list(APPEND monio_testinput
 )
 
 foreach(FILENAME ${monio_testinput})
-  execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink
-                           ${CMAKE_CURRENT_SOURCE_DIR}/${FILENAME}
-                           ${CMAKE_CURRENT_BINARY_DIR}/${FILENAME})
-endforeach(FILENAME)
+  file(
+    CREATE_LINK
+    ${CMAKE_CURRENT_SOURCE_DIR}/${FILENAME}
+    ${CMAKE_CURRENT_BINARY_DIR}/${FILENAME}
+    SYMBOLIC
+  )
+endforeach()
 
-ecbuild_add_test(TARGET monio_coding_norms
-                 TYPE SCRIPT
-                 COMMAND ${CMAKE_BINARY_DIR}/bin/monio_cpplint.py
-                 ARGS --quiet --recursive
-                       ${PROJECT_SOURCE_DIR}/src
-                       ${PROJECT_SOURCE_DIR}/test)
+# We can make use of CMake's native support of cpplint in future. If we set
+# `CMAKE_<LANG>_CPPLINT` (where `<LANG>` is either `C` or `CXX`) to point to
+# the `cpplint` executable, it will run `cpplint` as part of the build.
+find_program(
+  CPPLINT_EXECUTABLE
+  NAMES cpplint
+  DOC "Path to the cpplint executable"
+)
+if(CPPLINT_EXECUTABLE)
+  ecbuild_add_test(
+    TARGET "${PROJECT_NAME}_coding_norms"
+    LABELS lint
+    TYPE SCRIPT
+    COMMAND "${CPPLINT_EXECUTABLE}"
+    ARGS --quiet --recursive "${PROJECT_SOURCE_DIR}"
+  )
+endif()
 
 if(NOT IS_DIRECTORY "${MONIO_TESTFILES_DIR}")
   message(WARNING
@@ -81,20 +89,23 @@ if(NOT IS_DIRECTORY "${MONIO_TESTFILES_DIR}")
   return()
 endif()
 
-ecbuild_add_test(TARGET  test_monio_fieldset_write
-                 SOURCES mains/TestFieldSetWrite.cc
-                 ARGS    "testinput/fieldset_write.yaml"
-                 LIBS    monio
-                 MPI     4)
+ecbuild_add_test(
+  TARGET  test_monio_fieldset_write
+  SOURCES mains/TestFieldSetWrite.cc
+  ARGS    "testinput/fieldset_write.yaml"
+  LIBS    monio
+  MPI     4)
 
-ecbuild_add_test(TARGET  test_monio_state_basic
-                 SOURCES mains/TestStateBasic.cc
-                 ARGS    "testinput/state_basic.yaml"
-                 LIBS    monio
-                 MPI     4)
+ecbuild_add_test(
+  TARGET  test_monio_state_basic
+  SOURCES mains/TestStateBasic.cc
+  ARGS    "testinput/state_basic.yaml"
+  LIBS    monio
+  MPI     4)
 
-ecbuild_add_test(TARGET  test_monio_state_full
-                 SOURCES mains/TestStateFull.cc
-                 ARGS    "testinput/state_full.yaml"
-                 LIBS    monio
-                 MPI     4)
+ecbuild_add_test(
+  TARGET  test_monio_state_full
+  SOURCES mains/TestStateFull.cc
+  ARGS    "testinput/state_full.yaml"
+  LIBS    monio
+  MPI     4)


### PR DESCRIPTION
Modify cpplint target to use `cpplint` from the environment.

~Remove cpplint.py from lfric-jedi's source tree.~

cpplint 2.0.2 happiness
- Update filter categories.
- Fix new violations, `build/include_what_you_use`.

Add cmakelint to CI and fix violations.